### PR TITLE
docs: update documentation for solver fallbacks, multivariate Y and sparse matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ The `Regressor` class includes the following list of parameters:
 - model: str, default=‘lm’
   - Type of model to fit.
     Options are ‘lm’ (linear regression), ‘qr’ (quantile regression),
-    ‘logit’ (logistic regression for binary classification, output binary
-    classification), ‘logit_proba’ (logistic regression for binary
-    classification, output probability) and ‘logit_raw’ (logistic
-    regression for binary classification, output score before logistic).
+    and ‘logit’ (logistic regression for binary classification).
+    Both ‘lm’ and ‘qr’ models support multivariate regression (multiple outputs),
+    allowing for simultaneous fitting and coupled feature selection with
+    grouped penalizations.
 - penalization: str or None, default=‘lasso’
   - Type of penalization to use.
     Options are ‘lasso’, ‘ridge’, ‘gl’ (group lasso), ‘sgl’ (sparse group
@@ -109,11 +109,20 @@ The `Regressor` class includes the following list of parameters:
     penalizations in sgl and asgl penalizations.
     `alpha=1` enforces a lasso penalization while `alpha=0` enforces a
     group lasso penalization.
-- solver: str, default=‘default’
-  - Solver to be used by `cvxpy`.
+- solver: str or list of str, default=‘default’
+  - Solver(s) to be used by `cvxpy`.
     Default uses optimal alternative depending on the problem.
+    If a list is provided, the model will try each solver in order.
+    If the specified solver(s) fail, the model falls back to other installed solvers.
+    See [CVXPY Solvers](https://www.cvxpy.org/tutorial/advanced/index.html#solve-method-options)
+    for more information.
     Users can check available solvers via the
     command `cvxpy.installed_solvers()`.
+- canon_backend: str, default=‘CPP’
+  - Canonicalization backend to be used by `cvxpy`.
+    Options include ‘CPP’ (default), ‘SCIPY’, and ‘COO’.
+    See [CVXPY Canonicalization Backends](https://www.cvxpy.org/tutorial/advanced/index.html#canonicalization-backends)
+    for more information.
 - weight_technique: str, default=‘pca_pct’
   - Technique used to fit adaptive weights.
     Options include ‘pca_1’, ‘pca_pct’, ‘pls_1’, ‘pls_pct’, ‘lasso’,
@@ -136,6 +145,7 @@ The `Regressor` class includes the following list of parameters:
     components.
     This parameter only has effect in adaptiv penalizations where
     `weight_technique` is equal to ‘pca_pct’, ‘pls_pct’ or ‘sparse_pca’.
+    **Note:** For sparse input matrices, this value must be set to 1.
 - lambda1_weights: float, default=0.1
   - The value of the parameter `lambda1` used to solve the lasso model if
     `weight_technique='lasso'`

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Version](https://img.shields.io/badge/version-2.1.4-blue.svg)](https://cran.r-pr
 ## Fork of original asgl to incorporate sparse matrices
 
 This is a fork of asgl to incorporate sparse matrices.
+In addition to sparse matrix support, several other key features have been added:
 
-The changes are done in a somewhat janky way, as python is not my main
-language.
-In particular, for sparse matrices, `variability_pct` must be set to 1.
+*   **Multivariate Regression:** Both linear ('lm') and quantile ('qr') models now support multiple outputs (Multivariate Y), allowing for simultaneous fitting and coupled feature selection with grouped penalizations.
+*   **Solver Fallbacks:** The `solver` parameter now accepts a list of solvers. If the primary solver fails, the model will automatically try subsequent solvers in the list or fall back to other installed CVXPY solvers.
+*   **Canonicalization Backends:** A new `canon_backend` parameter allows users to choose the CVXPY canonicalization backend (e.g., 'CPP', 'SCIPY', 'COO') for better performance or compatibility.
 
+**Note:** For sparse matrices, `variability_pct` must be set to 1.
 Hence, a new `test_skmodels_sparse.py` specifically for sparse matrices has
 the `variability_pct=1`.
 

--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -721,6 +721,8 @@ class Regressor(BaseModel, AdaptiveWeights):
             - 'lm': linear regression models.
             - 'qr': quantile regression models.
             - 'logit': logistic regression for binary classification, output binary classification.
+        Both 'lm' and 'qr' models support multivariate regression (multiple outputs),
+        allowing for simultaneous fitting and coupled feature selection with grouped penalizations.
     penalization: str or None, default = 'lasso'
         Penalization to use. Currently, accepts:
             - None: unpenalized model.
@@ -745,6 +747,10 @@ class Regressor(BaseModel, AdaptiveWeights):
         ``alpha=1`` enforces a lasso while ``alpha=0`` enforces a group lasso.
     solver: str, default='CLARABEL'
         Solver to be used by cvxpy. Default uses open source convex programming solver CLARABEL.
+        If a list is provided, the model will try each solver in order.
+        If the specified solver(s) fail, the model falls back to other installed solvers.
+        See `CVXPY Solvers <https://www.cvxpy.org/tutorial/advanced/index.html#solve-method-options>`_
+        for more information.
         Users can check available solvers via the command `cp.installed_solvers()`.
     weight_technique: str, default='pca_pct'
         Weight technique used to fit the adaptive weights. Currently, accepts:
@@ -765,6 +771,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     variability_pct: float, default=0.9
         Percentage of variability explained by pca, pls and sparse_pca components. It only has effect if
         `` weight_technique`` is one of the following: 'pca_pct', 'pls_pct', 'sparse_pca'.
+        **Note:** For sparse input matrices, this value must be set to 1.
     lambda1_weights: float, default=0.1
         The value of the parameter ``lambda1`` used to solve the lasso model if ``weight_technique='lasso'`` or
         the ridge if ``weight_technique='ridge'``
@@ -785,6 +792,11 @@ class Regressor(BaseModel, AdaptiveWeights):
         be 0.
     weight_tol: float, default=1e-4
         Tolerance value used to avoid ZeroDivision errors when computing the weights.
+    canon_backend: str, default='CPP'
+        Canonicalization backend to be used by ``cvxpy``.
+        Options include 'CPP' (default), 'SCIPY', and 'COO'.
+        See `CVXPY Canonicalization Backends <https://www.cvxpy.org/tutorial/advanced/index.html#canonicalization-backends>`_
+        for more information.
 
     Attributes
     ----------

--- a/tests/test_skmodels_sparse_updated.py
+++ b/tests/test_skmodels_sparse_updated.py
@@ -903,7 +903,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -933,7 +933,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -963,7 +963,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -993,7 +993,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1023,7 +1023,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1084,7 +1084,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1121,7 +1121,7 @@ def test_alasso_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1150,7 +1150,7 @@ def test_alasso_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 
@@ -1276,7 +1276,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1306,7 +1306,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1336,7 +1336,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1366,7 +1366,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1395,7 +1395,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1456,7 +1456,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1578,7 +1578,7 @@ def test_agl_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1616,7 +1616,7 @@ def test_agl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1646,7 +1646,7 @@ def test_agl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 
@@ -1773,7 +1773,7 @@ def test_asgl_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1812,7 +1812,7 @@ def test_asgl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1843,7 +1843,7 @@ def test_asgl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 


### PR DESCRIPTION
This PR updates the documentation to reflect recent features and requirements in `asgl`.

**Documentation Updates:**
- **Multivariate Y:** Explicitly documented that `lm` (linear) and `qr` (quantile) models support multivariate regression (multiple outputs), enabling simultaneous fitting and coupled feature selection with grouped penalizations.
- **Solver Fallbacks:** Updated the `solver` parameter description to explain that it accepts a list of solvers. Documented the fallback behavior (trying specified solvers in order, then falling back to other installed solvers) and added a link to the CVXPY documentation.
- **Canon Backends:** Added documentation for the `canon_backend` parameter, explaining its options ('CPP', 'SCIPY', 'COO') and linking to the relevant CVXPY documentation.
- **Sparse Matrices:** Added a critical note to the `variability_pct` parameter documentation, stating that for sparse input matrices, this value **must** be set to 1.
- **Removed Deprecated Options:** Removed `logit_proba` and `logit_raw` from the `model` parameter options in `README.md` as they are no longer supported in the `Regressor` class.

**Test Fixes:**
- Fixed several syntax errors (unterminated string literals) in `tests/test_skmodels_sparse_updated.py` that were preventing the test suite from running.

**Verification:**
- Verified documentation changes by running `pytest`.
- Confirmed that `tests/test_skmodels.py` passes.
- Confirmed that `tests/test_skmodels_sparse_updated.py` is now collectible by pytest (although some tests fail due to known precision issues with sparse adaptive weights).

---
*PR created automatically by Jules for task [11053194538806570305](https://jules.google.com/task/11053194538806570305) started by @zeyuz35*