### PR TITLE
🧪 Test improvement: Validate negative group_index handling

### DIFF
--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -818,6 +818,20 @@ def test_errors():
                        match=f'The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.'):
         model.fit(X, y)
 
+
+def test_negative_group_index_raises_error():
+    # Generate dummy data
+    X = np.random.rand(10, 5)
+    y = np.random.rand(10)
+
+    # Create a group_index with a negative value
+    group_index = np.array([1, 1, 2, 2, -1])
+
+    model = Regressor(model='lm', penalization='gl', lambda1=0.1)
+
+    with pytest.raises(ValueError, match="group_index must be a positive integer array. Negative values detected"):
+        model.fit(X, y, group_index=group_index)
+
 # SKLEARN COMPATIBILITY -----------------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
🧪 Test improvement: Validate negative group_index handling

🎯 **What:**
Added a unit test to verify that the `Regressor` class correctly raises a `ValueError` when `group_index` contains negative values.

📊 **Coverage:**
- Covered the validation logic for `group_index` in `asgl/skmodels.py`.
- Specifically targets the check: `if any(group_index < 0): raise ValueError(...)`.

✨ **Result:**
- Improved test coverage for input validation edge cases.
- Confirmed that the `Regressor` enforces the requirement for positive integer arrays for group indices.

---
*PR created automatically by Jules for task [4553826431814190828](https://jules.google.com/task/4553826431814190828) started by @zeyuz35*