### PR TITLE
Optimize group index lookups in penalized regression models

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Sequence, Optional, Tuple, Union
+from typing import Sequence, Optional, Tuple, Union, Dict
 from sklearn.utils.validation import check_is_fitted, check_X_y, check_scalar
 import cvxpy as cp
 import numpy as np
@@ -30,6 +30,20 @@ warnings.filterwarnings(
     category=UserWarning,
     message="You are solving a parameterized problem that is not DPP",
 )
+
+
+def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
+    """
+    Efficiently computes group sizes and indices for each group.
+    """
+    argsort_indices = np.argsort(group_index, kind='mergesort')
+    sorted_group_index = group_index[argsort_indices]
+    unique_groups, group_starts, group_counts = np.unique(sorted_group_index, return_index=True, return_counts=True)
+    indices_per_group = {
+        g: argsort_indices[start : start + count]
+        for g, start, count in zip(unique_groups, group_starts, group_counts)
+    }
+    return unique_groups, group_counts, indices_per_group
 
 
 class BaseModel(BaseEstimator, RegressorMixin):
@@ -243,8 +257,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
 
     def _gl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
         lambda_param = cp.Parameter(nonneg=True, value=self.lambda1)
-        unique_groups, group_sizes = np.unique(group_index, return_counts=True)
-        indices_per_group = {g: np.where(group_index == g)[0] for g in unique_groups}
+        unique_groups, group_sizes, indices_per_group = _get_group_info(group_index)
         sqrt_sizes = np.sqrt(group_sizes)
         group_norms = cp.hstack(
             [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
@@ -255,8 +268,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
         group_param = cp.Parameter(nonneg=True, value=self.lambda1 * (1 - self.alpha))
         individual_param = cp.Parameter(nonneg=True, value=self.lambda1 * self.alpha)
-        unique_groups, group_sizes = np.unique(group_index, return_counts=True)
-        indices_per_group = {g: np.where(group_index == g)[0] for g in unique_groups}
+        unique_groups, group_sizes, indices_per_group = _get_group_info(group_index)
         sqrt_sizes = np.sqrt(group_sizes)
         group_norms = cp.hstack(
             [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
@@ -692,10 +704,10 @@ class AdaptiveWeights:
             if tmp_weight is None:
                 tmp_weight = getattr(self, "_w" + self.weight_technique)(X=X, y=y)
             group_index = np.asarray(group_index, dtype=int)
-            unique_index = np.unique(group_index)
+            unique_groups, group_counts, indices_per_group = _get_group_info(group_index)
             group_weights = []
-            for g in unique_index:
-                mask = group_index == g
+            for g in unique_groups:
+                mask = indices_per_group[g]
                 norm = np.linalg.norm(tmp_weight[mask], ord=2)
                 group_weights.append(
                     1.0 / (np.power(norm, self.group_power_weight) + self.weight_tol)
@@ -869,8 +881,7 @@ class Regressor(BaseModel, AdaptiveWeights):
 
     def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
         lambda_param = cp.Parameter(nonneg=True, value=self.lambda1)
-        unique_groups, group_sizes = np.unique(group_index, return_counts=True)
-        indices_per_group = {g: np.where(group_index == g)[0] for g in unique_groups}
+        unique_groups, group_sizes, indices_per_group = _get_group_info(group_index)
         sqrt_sizes = np.sqrt(group_sizes)
         group_weights = cp.Parameter(
             len(sqrt_sizes), nonneg=True, value=sqrt_sizes * self.group_weights
@@ -891,8 +902,7 @@ class Regressor(BaseModel, AdaptiveWeights):
         weights = np.asarray(self.individual_weights).reshape(-1, 1)
         individual_weights_param = cp.Parameter((mx, 1), nonneg=True, value=weights)
         group_param = cp.Parameter(nonneg=True, value=self.lambda1 * (1 - self.alpha))
-        unique_groups, group_sizes = np.unique(group_index, return_counts=True)
-        indices_per_group = {g: np.where(group_index == g)[0] for g in unique_groups}
+        unique_groups, group_sizes, indices_per_group = _get_group_info(group_index)
         sqrt_sizes = np.sqrt(group_sizes)
         group_weights = cp.Parameter(
             len(sqrt_sizes), nonneg=True, value=sqrt_sizes * self.group_weights

--- a/tests/test_skmodels_sparse_updated.py
+++ b/tests/test_skmodels_sparse_updated.py
@@ -903,7 +903,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -933,7 +933,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -963,7 +963,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -993,7 +993,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1023,7 +1023,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1084,7 +1084,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1121,7 +1121,7 @@ def test_alasso_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1150,7 +1150,7 @@ def test_alasso_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 
@@ -1276,7 +1276,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1306,7 +1306,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1336,7 +1336,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1366,7 +1366,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1395,7 +1395,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1456,7 +1456,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1578,7 +1578,7 @@ def test_agl_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1616,7 +1616,7 @@ def test_agl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1646,7 +1646,7 @@ def test_agl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 
@@ -1773,7 +1773,7 @@ def test_asgl_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1812,7 +1812,7 @@ def test_asgl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1843,7 +1843,7 @@ def test_asgl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 


### PR DESCRIPTION
This PR optimizes the group index lookup mechanism in the `asgl` library. 

**Changes:**
- Implemented a new helper function `_get_group_info` in `asgl/skmodels.py` that utilizes `np.argsort` (stable sort) to efficiently group indices.
- Replaced the previous $O(G \times N)$ implementation (which iterated over unique groups and used `np.where` for each) with this new $O(N \log N)$ approach in:
    - `BaseModel._gl`
    - `BaseModel._sgl`
    - `AdaptiveWeights.fit_weights`
    - `Regressor._agl`
    - `Regressor._asgl`
- Fixed syntax errors (unterminated string literals) in `tests/test_skmodels_sparse_updated.py` that were preventing the test suite from executing.

**Performance:**
- The new implementation avoids repeated full scans of the index array, making it much more scalable for high-dimensional problems with many groups.

**Verification:**
- Verified that the new logic produces identical groups and indices as the old implementation using a temporary benchmark script.
- Ran existing tests. Failures in `test_skmodels_sparse_updated.py` were observed but identified as pre-existing precision issues related to solver variability, as noted in the project memory. The logic changes preserve the exact order of indices (via stable sort), ensuring numerical equivalence where possible.

---
*PR created automatically by Jules for task [13146190104765498391](https://jules.google.com/task/13146190104765498391) started by @zeyuz35*