### PR TITLE
🧪 Add validation test for group_weights length

### DIFF
--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -818,6 +818,22 @@ def test_errors():
                        match=f'The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.'):
         model.fit(X, y)
 
+def test_group_weights_validation():
+    # Synthetic data
+    X = np.random.randn(10, 5)
+    y = np.random.randn(10)
+    # 3 groups: 1, 2, 3
+    group_index = [1, 1, 2, 2, 3]
+
+    # mismatch: 2 weights for 3 groups
+    group_weights = np.array([1.0, 1.0])
+
+    model = Regressor(model='lm', penalization='agl', lambda1=0.1, group_weights=group_weights, solver='CLARABEL')
+
+    with pytest.raises(ValueError, match="Number of group weights does not match the number of groups in group_index"):
+        model.fit(X, y, group_index=group_index)
+
+
 # SKLEARN COMPATIBILITY -----------------------------------------------------------------------------------------------
 
 

--- a/tests/test_skmodels_sparse_updated.py
+++ b/tests/test_skmodels_sparse_updated.py
@@ -903,7 +903,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -933,7 +933,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -963,7 +963,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -993,7 +993,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1023,7 +1023,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1084,7 +1084,7 @@ def test_alasso_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1121,7 +1121,7 @@ def test_alasso_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1150,7 +1150,7 @@ def test_alasso_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 
@@ -1276,7 +1276,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1306,7 +1306,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1336,7 +1336,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1366,7 +1366,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1395,7 +1395,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1425,7 +1425,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized" and power_weight=1.2',
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized" and power_weight=1.2"',
     )
 
     model = Regressor(
@@ -1456,7 +1456,7 @@ def test_aridge_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive ridge lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1578,7 +1578,7 @@ def test_agl_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1616,7 +1616,7 @@ def test_agl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1646,7 +1646,7 @@ def test_agl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive group lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive group lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 
@@ -1773,7 +1773,7 @@ def test_asgl_lm():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso lm failure for lambda=0.1, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso lm failure for lambda=0.1, weight_technique="unpenalized"',
     )
 
 
@@ -1812,7 +1812,7 @@ def test_asgl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso qr failure for quantile 0.8, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso qr failure for quantile 0.8, weight_technique="unpenalized"',
     )
 
     model = Regressor(
@@ -1843,7 +1843,7 @@ def test_asgl_qr():
             ]
         ),
         decimal=3,
-        err_msg='Adaptive sparse group lasso qr failure for quantile 0.2, weight_technique="unpenalized",
+        err_msg='Adaptive sparse group lasso qr failure for quantile 0.2, weight_technique="unpenalized"',
     )
 
 


### PR DESCRIPTION
🎯 **What:**
- Added a new test `test_group_weights_validation` in `tests/test_skmodels.py` to verify that `asgl.Regressor` raises a `ValueError` when the number of provided `group_weights` does not match the number of unique groups in `group_index` for adaptive group penalizations.
- Fixed syntax errors in `tests/test_skmodels_sparse_updated.py` where string literals were not properly terminated, causing the test suite to fail collection.

📊 **Coverage:**
- The new test specifically covers the condition `if bool_group and (len(self.group_weights) != len(np.unique(group_index)))` in `asgl/skmodels.py`, ensuring the correct exception is raised.
- The syntax fixes ensure `tests/test_skmodels_sparse_updated.py` is included in test collection and execution.

✨ **Result:**
- Verified that providing an incorrect length of `group_weights` correctly raises `ValueError: Number of group weights does not match the number of groups in group_index`.
- Improved the reliability of the test suite by fixing existing syntax errors.

---
*PR created automatically by Jules for task [8036426515692384658](https://jules.google.com/task/8036426515692384658) started by @zeyuz35*