### PR TITLE
🔐 Fix state leakage in AdaptiveWeights.fit_weights

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -695,29 +695,38 @@ class AdaptiveWeights:
                 "A group penalisation was requested but `group_index` is missing."
             )
         tmp_weight: Optional[np.ndarray] = None
-        if bool_individual and self.individual_weights is None:
-            tmp_weight = getattr(self, "_w" + self.weight_technique)(X=X, y=y)
-            self.individual_weights = 1 / (
-                tmp_weight**self.individual_power_weight + self.weight_tol
-            )
-        if bool_group and self.group_weights is None:
-            if tmp_weight is None:
+        if bool_individual:
+            if self.individual_weights is None:
                 tmp_weight = getattr(self, "_w" + self.weight_technique)(X=X, y=y)
-            group_index = np.asarray(group_index, dtype=int)
-            unique_groups, group_counts, indices_per_group = _get_group_info(group_index)
-            group_weights = []
-            for g in unique_groups:
-                mask = indices_per_group[g]
-                norm = np.linalg.norm(tmp_weight[mask], ord=2)
-                group_weights.append(
-                    1.0 / (np.power(norm, self.group_power_weight) + self.weight_tol)
+                self.individual_weights_ = 1 / (
+                    tmp_weight**self.individual_power_weight + self.weight_tol
                 )
-            self.group_weights = np.asarray(group_weights)
-        if bool_individual and (len(self.individual_weights) != X.shape[1]):
+            else:
+                self.individual_weights_ = self.individual_weights
+
+        if bool_group:
+            if self.group_weights is None:
+                if tmp_weight is None:
+                    tmp_weight = getattr(self, "_w" + self.weight_technique)(X=X, y=y)
+                group_index = np.asarray(group_index, dtype=int)
+                unique_groups, group_counts, indices_per_group = _get_group_info(group_index)
+                group_weights = []
+                for g in unique_groups:
+                    mask = indices_per_group[g]
+                    norm = np.linalg.norm(tmp_weight[mask], ord=2)
+                    group_weights.append(
+                        1.0
+                        / (np.power(norm, self.group_power_weight) + self.weight_tol)
+                    )
+                self.group_weights_ = np.asarray(group_weights)
+            else:
+                self.group_weights_ = self.group_weights
+
+        if bool_individual and (len(self.individual_weights_) != X.shape[1]):
             raise ValueError(
                 "Number of individual weights does not match the number of columns in X"
             )
-        if bool_group and (len(self.group_weights) != len(np.unique(group_index))):
+        if bool_group and (len(self.group_weights_) != len(np.unique(group_index))):
             raise ValueError(
                 "Number of group weights does not match the number of groups in group_index"
             )
@@ -873,7 +882,7 @@ class Regressor(BaseModel, AdaptiveWeights):
         lambda_param = cp.Parameter(nonneg=True, value=self.lambda1)
         mx, my = beta_var.shape
         # Reshape weights to (mx, 1) for proper broadcasting across my outputs
-        weights = np.asarray(self.individual_weights).reshape(-1, 1)
+        weights = np.asarray(self.individual_weights_).reshape(-1, 1)
         individual_weights_param = cp.Parameter((mx, 1), nonneg=True, value=weights)
         pen = lambda_param * cp.sum_squares(
             cp.multiply(individual_weights_param, beta_var)
@@ -886,7 +895,7 @@ class Regressor(BaseModel, AdaptiveWeights):
         lambda_param = cp.Parameter(nonneg=True, value=self.lambda1)
         mx, my = beta_var.shape
         # Reshape weights to (mx, 1) for proper broadcasting across my outputs
-        weights = np.asarray(self.individual_weights).reshape(-1, 1)
+        weights = np.asarray(self.individual_weights_).reshape(-1, 1)
         individual_weights_param = cp.Parameter((mx, 1), nonneg=True, value=weights)
         pen = lambda_param * cp.norm1(cp.multiply(individual_weights_param, beta_var))
         return pen
@@ -896,7 +905,7 @@ class Regressor(BaseModel, AdaptiveWeights):
         unique_groups, group_sizes, indices_per_group = _get_group_info(group_index)
         sqrt_sizes = np.sqrt(group_sizes)
         group_weights = cp.Parameter(
-            len(sqrt_sizes), nonneg=True, value=sqrt_sizes * self.group_weights
+            len(sqrt_sizes), nonneg=True, value=sqrt_sizes * self.group_weights_
         )
         mx, my = beta_var.shape
         # For each group, compute the norm of all features in that group across all outputs
@@ -911,13 +920,13 @@ class Regressor(BaseModel, AdaptiveWeights):
         individual_param = cp.Parameter(nonneg=True, value=self.lambda1 * self.alpha)
         mx, my = beta_var.shape
         # Reshape individual weights to (mx, 1) for proper broadcasting across my outputs
-        weights = np.asarray(self.individual_weights).reshape(-1, 1)
+        weights = np.asarray(self.individual_weights_).reshape(-1, 1)
         individual_weights_param = cp.Parameter((mx, 1), nonneg=True, value=weights)
         group_param = cp.Parameter(nonneg=True, value=self.lambda1 * (1 - self.alpha))
         unique_groups, group_sizes, indices_per_group = _get_group_info(group_index)
         sqrt_sizes = np.sqrt(group_sizes)
         group_weights = cp.Parameter(
-            len(sqrt_sizes), nonneg=True, value=sqrt_sizes * self.group_weights
+            len(sqrt_sizes), nonneg=True, value=sqrt_sizes * self.group_weights_
         )
         # For each group, compute the norm of all features in that group across all outputs
         group_norms = cp.hstack(

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,0 +1,43 @@
+import numpy as np
+from asgl import Regressor
+from sklearn.datasets import make_regression
+import pytest
+
+def test_group_weights_leakage():
+    # 1. Setup first dataset
+    X1, y1 = make_regression(n_samples=10, n_features=4, noise=0.1, random_state=42)
+    group_index = [0, 0, 1, 1]
+
+    # Check group weights leakage (agl)
+    model = Regressor(model='lm', penalization='agl', weight_technique='pca_pct', lambda1=0.1)
+
+    model.fit(X1, y1, group_index=group_index)
+    weights1 = model.group_weights_
+
+    # 2. Setup second dataset (very different scale)
+    X2, y2 = make_regression(n_samples=10, n_features=4, noise=0.1, random_state=43)
+    X2 = X2 * 100
+
+    model.fit(X2, y2, group_index=group_index)
+    weights2 = model.group_weights_
+
+    assert not np.allclose(weights1, weights2), "Group weights leaked across fit calls"
+
+def test_individual_weights_leakage():
+    # 1. Setup first dataset
+    X1, y1 = make_regression(n_samples=10, n_features=4, noise=0.1, random_state=42)
+
+    # Check individual weights leakage (alasso)
+    model = Regressor(model='lm', penalization='alasso', weight_technique='pca_pct', lambda1=0.1)
+
+    model.fit(X1, y1)
+    iweights1 = model.individual_weights_
+
+    # 2. Setup second dataset (very different scale)
+    X2, y2 = make_regression(n_samples=10, n_features=4, noise=0.1, random_state=43)
+    X2 = X2 * 100
+
+    model.fit(X2, y2)
+    iweights2 = model.individual_weights_
+
+    assert not np.allclose(iweights1, iweights2), "Individual weights leaked across fit calls"


### PR DESCRIPTION
🎯 **What:**
Fixed a state leakage vulnerability where `AdaptiveWeights` modified its own initialization parameters (`individual_weights` and `group_weights`) during fitting.

⚠️ **Risk:**
If a `Regressor` instance was reused (fitted multiple times on different data), the weights from the first fit would persist and be used in subsequent fits, leading to incorrect models and potentially leaking information about the first dataset into the second model.

🛡️ **Solution:**
Introduced internal attributes `individual_weights_` and `group_weights_` to store the learned weights. The public attributes are now treated as immutable configuration. The penalization logic was updated to use these new internal attributes.


---
*PR created automatically by Jules for task [2668548917775330935](https://jules.google.com/task/2668548917775330935) started by @zeyuz35*