### PR TITLE
🔒 [Security] Fix Global Warning Suppression in Library Code

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -25,12 +25,6 @@ GROUP_ADAPTIVE = ["agl", "asgl"]
 ALL_PENALTIES = INDIV_NONADAPTIVE + INDIV_ADAPTIVE + GROUP_ADAPTIVE + GROUP_NONADAPTIVE
 ALLOWED_MODELS = ["lm", "qr", "logit"]
 
-warnings.filterwarnings(
-    action="ignore",
-    category=UserWarning,
-    message="You are solving a parameterized problem that is not DPP",
-)
-
 
 def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
     """
@@ -168,11 +162,17 @@ class BaseModel(BaseEstimator, RegressorMixin):
             # "default" means pass solver=None so cvxpy picks its own default
             cp_solver = None if solver_name == "default" else solver_name
             try:
-                problem.solve(
-                    solver=cp_solver,
-                    verbose=self.verbose,
-                    canon_backend=self.canon_backend,
-                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        action="ignore",
+                        category=UserWarning,
+                        message="You are solving a parameterized problem that is not DPP",
+                    )
+                    problem.solve(
+                        solver=cp_solver,
+                        verbose=self.verbose,
+                        canon_backend=self.canon_backend,
+                    )
                 if problem.status is not None and "optimal" in problem.status.lower():
                     solved = True
                     break
@@ -205,11 +205,17 @@ class BaseModel(BaseEstimator, RegressorMixin):
                 )
             for alt_solver in remaining:
                 try:
-                    problem.solve(
-                        solver=alt_solver,
-                        verbose=self.verbose,
-                        canon_backend=self.canon_backend,
-                    )
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(
+                            action="ignore",
+                            category=UserWarning,
+                            message="You are solving a parameterized problem that is not DPP",
+                        )
+                        problem.solve(
+                            solver=alt_solver,
+                            verbose=self.verbose,
+                            canon_backend=self.canon_backend,
+                        )
                     if problem.status is not None and "optimal" in problem.status.lower():
                         warnings.warn(
                             f"Successfully solved with fallback solver: {alt_solver}",

--- a/test_warning.py
+++ b/test_warning.py
@@ -1,0 +1,41 @@
+import warnings
+from asgl.skmodels import Regressor
+import numpy as np
+import cvxpy as cp
+
+X = np.random.randn(10, 2)
+y = np.random.randn(10)
+group_index = [1, 2]
+
+# Setup to show all warnings
+warnings.simplefilter("always")
+
+print("Checking global state before fitting...")
+with warnings.catch_warnings(record=True) as w:
+    x = cp.Variable()
+    p = cp.Parameter(value=2.0)
+    prob = cp.Problem(cp.Minimize(p * cp.square(x)))
+    try:
+        prob.solve()
+    except Exception:
+        pass
+
+    print("Global warnings emitted:", [warn.message for warn in w])
+
+print("\nFitting model...")
+model = Regressor(model="lm", penalization="asgl", lambda1=0.1)
+with warnings.catch_warnings(record=True) as w:
+    model.fit(X, y, group_index=group_index)
+    print("Fitting warnings emitted:", [warn.message for warn in w])
+
+print("\nChecking global state after fitting...")
+with warnings.catch_warnings(record=True) as w:
+    x = cp.Variable()
+    p = cp.Parameter(value=2.0)
+    prob = cp.Problem(cp.Minimize(p * cp.square(x)))
+    try:
+        prob.solve()
+    except Exception:
+        pass
+
+    print("Global warnings emitted:", [warn.message for warn in w])


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Removed a module-level `warnings.filterwarnings` call that was indiscriminately ignoring `UserWarning`s related to `cvxpy`'s DPP checks. The suppression has been scoped correctly using `warnings.catch_warnings()` context managers strictly around the `problem.solve()` calls.

⚠️ **Risk:** The potential impact if left unfixed
Module-level `warnings.filterwarnings` calls in library code modify the global warnings registry for the entire Python process. This means that users importing `asgl` would silently stop receiving `UserWarning`s from `cvxpy` (or potentially other libraries if the message matches loosely) in their own applications, which could obscure important issues, bugs, or performance warnings in user code.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the global module-level warning filter with local context managers (`with warnings.catch_warnings():`) directly wrapping the specific `problem.solve()` invocations where the DPP warnings are expected. This ensures the warning is suppressed only during `asgl`'s internal optimization routines and does not leak out to pollute the user's global execution environment.

---
*PR created automatically by Jules for task [17390361337839921519](https://jules.google.com/task/17390361337839921519) started by @zeyuz35*