### PR TITLE
🧪 [testing improvement] Add validation test for negative group_index values

### DIFF
--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -1934,6 +1934,21 @@ def test_errors():
         model.fit(X, y)
 
 
+def test_negative_group_index_raises_error():
+    # Generate dummy data
+    X = np.random.rand(10, 5)
+    X = sparse.csr_matrix(X)
+    y = np.random.rand(10)
+
+    # Create a group_index with a negative value
+    group_index = np.array([1, 1, 2, 2, -1])
+
+    model = Regressor(model='lm', penalization='gl', lambda1=0.1, variability_pct=1)
+
+    with pytest.raises(ValueError, match="group_index must be a positive integer array. Negative values detected"):
+        model.fit(X, y, group_index=group_index)
+
+
 # SKLEARN COMPATIBILITY -----------------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the validation logic ensuring `group_index` contains only positive integers was not explicitly tested for the sparse matrix path in `tests/test_skmodels_sparse.py`.
📊 **Coverage:** A new test case `test_negative_group_index_raises_error` was added to `tests/test_skmodels_sparse.py`, ensuring that when `any(group_index < 0)` during `fit()`, a `ValueError` is correctly raised when using a sparse feature matrix.
✨ **Result:** Increased test coverage to verify that group index validation correctly operates independent of whether the input matrix is dense or sparse.

---
*PR created automatically by Jules for task [12345103508492148198](https://jules.google.com/task/12345103508492148198) started by @zeyuz35*