### PR TITLE
🧪 Add validation test for individual_weights length

### DIFF
--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -832,6 +832,20 @@ def test_negative_group_index_raises_error():
     with pytest.raises(ValueError, match="group_index must be a positive integer array. Negative values detected"):
         model.fit(X, y, group_index=group_index)
 
+
+def test_invalid_individual_weights_length_raises_error():
+    # Generate dummy data
+    X = np.random.rand(10, 5)
+    y = np.random.rand(10)
+
+    # Create individual_weights with an incorrect length (e.g., 4 instead of 5)
+    invalid_individual_weights = np.array([1.0, 1.0, 1.0, 1.0])
+
+    model = Regressor(model='lm', penalization='alasso', individual_weights=invalid_individual_weights)
+
+    with pytest.raises(ValueError, match="Number of individual weights does not match the number of columns in X"):
+        model.fit(X, y)
+
 # SKLEARN COMPATIBILITY -----------------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing validation test for the `individual_weights` array length in `asgl.skmodels.Regressor`. Specifically, it ensures that when an incorrectly sized array is passed, a `ValueError` is raised, as implemented in `asgl/skmodels.py` line 629.

📊 **Coverage:** What scenarios are now tested
A new test `test_invalid_individual_weights_length_raises_error` has been added to `tests/test_skmodels.py`. The test covers the scenario where a user provides a custom `individual_weights` array that does not match the number of columns (features) in the input matrix `X` when using adaptive penalizations like `alasso`.

✨ **Result:** The improvement in test coverage
We now explicitly test and verify the error handling path for invalid `individual_weights` inputs, making the model's initialization and `fit` method more robust and guaranteeing that users get a clear, descriptive exception instead of obscure internal numpy broadcasting or CVXPY errors down the line.

---
*PR created automatically by Jules for task [6420919601776990470](https://jules.google.com/task/6420919601776990470) started by @zeyuz35*