### PR TITLE
docs: remove sparse variability_pct warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,6 @@ In addition to sparse matrix support, several other key features have been added
 *   **Solver Fallbacks:** The `solver` parameter now accepts a list of solvers. If the primary solver fails, the model will automatically try subsequent solvers in the list or fall back to other installed CVXPY solvers.
 *   **Canonicalization Backends:** A new `canon_backend` parameter allows users to choose the CVXPY canonicalization backend (e.g., 'CPP', 'SCIPY', 'COO') for better performance or compatibility.
 
-**Note:** For sparse matrices, `variability_pct` must be set to 1.
-Hence, a new `test_skmodels_sparse.py` specifically for sparse matrices has
-the `variability_pct=1`.
-
-However, it should not interfere with original functionality if you pass
-dense matrices.
-
 Install via
 ```
 uv pip install --upgrade git+https://github.com/zeyuz35/asgl.git
@@ -147,7 +140,6 @@ The `Regressor` class includes the following list of parameters:
     components.
     This parameter only has effect in adaptiv penalizations where
     `weight_technique` is equal to ‘pca_pct’, ‘pls_pct’ or ‘sparse_pca’.
-    **Note:** For sparse input matrices, this value must be set to 1.
 - lambda1_weights: float, default=0.1
   - The value of the parameter `lambda1` used to solve the lasso model if
     `weight_technique='lasso'`


### PR DESCRIPTION
The issue requested removing the warning from `README.md` that stated `variability_pct` must be set to 1 for sparse matrices, as this is no longer a limitation (the feature has been added).

This commit removes:
1. The note in the "Fork of original asgl to incorporate sparse matrices" section stating `variability_pct` must be 1.
2. The specific note about `test_skmodels_sparse.py` having `variability_pct=1`.
3. The note in the parameter list for `variability_pct` saying sparse input matrices require this value to be 1.

The tests have been run and confirm that the documentation change did not cause any code regressions.

---
*PR created automatically by Jules for task [5396277319398486759](https://jules.google.com/task/5396277319398486759) started by @zeyuz35*