### PR TITLE
🛡️ Sentinel: [HIGH] Fix reflection vulnerability in weight_technique

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-02 - [Reflection Vulnerability via Unvalidated getattr]
+**Vulnerability:** Found unvalidated user input (`weight_technique`) being used directly inside a `getattr` call (`getattr(self, "_w" + self.weight_technique)`) within `AdaptiveWeights.fit_weights`.
+**Learning:** This is a reflection vulnerability where users could potentially instantiate objects with malicious techniques to execute unintended methods matching the `_w` prefix. Subclasses must rigorously validate dynamic attributes.
+**Prevention:** Implement input validation for variables driving `getattr`. Maintain an explicitly defined list of allowed values (e.g., `ALLOWED_WEIGHT_TECHNIQUES`) and assert the parameter exists in this subset.

--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -24,6 +24,7 @@ GROUP_NONADAPTIVE = ["gl", "sgl"]
 GROUP_ADAPTIVE = ["agl", "asgl"]
 ALL_PENALTIES = INDIV_NONADAPTIVE + INDIV_ADAPTIVE + GROUP_ADAPTIVE + GROUP_NONADAPTIVE
 ALLOWED_MODELS = ["lm", "qr", "logit"]
+ALLOWED_WEIGHT_TECHNIQUES = ["pca_1", "pca_pct", "pls_1", "pls_pct", "sparse_pca", "unpenalized", "lasso", "ridge"]
 
 
 def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
@@ -844,6 +845,14 @@ class Regressor(BaseModel, AdaptiveWeights):
     n_features_in_: int
         Number of features seen during fit.
     """
+
+    def _check_attributes(self) -> None:
+        super()._check_attributes()
+        check_scalar(self.weight_technique, "weight_technique", target_type=str)
+        if self.weight_technique not in ALLOWED_WEIGHT_TECHNIQUES:
+            raise ValueError(
+                f"weight_technique must be one of {sorted(ALLOWED_WEIGHT_TECHNIQUES)}; got {self.weight_technique}."
+            )
 
     def __init__(
         self,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `AdaptiveWeights.fit_weights` method used the unvalidated `self.weight_technique` attribute directly in a `getattr(self, "_w" + self.weight_technique)` call. This presents a reflection vulnerability where an attacker could theoretically execute unintended methods by passing carefully crafted strings.
🎯 Impact: While currently limited to the methods defined on the class, this creates a risk of exposing internal methods or triggering unintended behavior if the class structure changes in the future.
🔧 Fix: 
1. Defined `ALLOWED_WEIGHT_TECHNIQUES` containing only the explicitly supported techniques (`pca_1`, `pca_pct`, `pls_1`, `pls_pct`, `sparse_pca`, `unpenalized`, `lasso`, `ridge`).
2. Overrode `_check_attributes` in the `Regressor` class to validate that `self.weight_technique` is present in this allowlist before processing.
✅ Verification: 
- `python3 -m pytest tests/` passes successfully, ensuring no regressions.
- The `_check_attributes` method now properly intercepts invalid techniques and raises a `ValueError`.

---
*PR created automatically by Jules for task [1065461608615807324](https://jules.google.com/task/1065461608615807324) started by @zeyuz35*