### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure reflection in getattr dynamic dispatch

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Fix insecure reflection in getattr dynamic dispatch
+**Vulnerability:** The `weight_technique` parameter in the `Regressor` and `AdaptiveWeights` classes allowed for insecure reflection when dynamically looking up the weighting function using `getattr(self, "_w" + self.weight_technique)`. An attacker could pass arbitrary method names string fragments to be resolved and executed.
+**Learning:** Any user input that is concatenated to construct method or attribute names and passed to reflection utilities like `getattr` or `eval` must be strictly validated against an explicit allowlist.
+**Prevention:** Implement an allowlist for `weight_technique` (e.g., `ALLOWED_WEIGHT_TECHNIQUES`) and validate the user-provided string against this allowlist within the constructor validation method `_check_attributes()`.

--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -24,6 +24,16 @@ GROUP_NONADAPTIVE = ["gl", "sgl"]
 GROUP_ADAPTIVE = ["agl", "asgl"]
 ALL_PENALTIES = INDIV_NONADAPTIVE + INDIV_ADAPTIVE + GROUP_ADAPTIVE + GROUP_NONADAPTIVE
 ALLOWED_MODELS = ["lm", "qr", "logit"]
+ALLOWED_WEIGHT_TECHNIQUES = [
+    "pca_1",
+    "pca_pct",
+    "pls_1",
+    "pls_pct",
+    "sparse_pca",
+    "unpenalized",
+    "lasso",
+    "ridge",
+]
 
 
 def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
@@ -117,6 +127,12 @@ class BaseModel(BaseEstimator, RegressorMixin):
             raise ValueError(
                 f"penalization must be one of {sorted(ALL_PENALTIES)}; got {self.penalization}."
             )
+        if hasattr(self, "weight_technique"):
+            check_scalar(self.weight_technique, "weight_technique", target_type=str)
+            if self.weight_technique not in ALLOWED_WEIGHT_TECHNIQUES:
+                raise ValueError(
+                    f"weight_technique must be one of {sorted(ALLOWED_WEIGHT_TECHNIQUES)}; got {self.weight_technique}."
+                )
 
     def _quantile_function(self, X) -> cp.Expression:
         """cp quantile loss function."""


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `weight_technique` parameter was passed as a string directly into `getattr(self, "_w" + self.weight_technique)` to resolve which weight calculating method to use. Because `weight_technique` was not strictly validated against an allowlist, an attacker could supply specially crafted strings to cause the class to look up and invoke arbitrary attributes or functions starting with `_w`, leading to insecure reflection.
🎯 Impact: While the prefix limits the scope of callable attributes, providing unregulated access to internal structure via reflection bypasses intended access boundaries.
🔧 Fix: Created `ALLOWED_WEIGHT_TECHNIQUES` to maintain a strict allowlist of accepted techniques. Updated `_check_attributes()` to proactively validate that the input provided matches this list, rejecting unauthorized parameters explicitly.
✅ Verification: Tested the new `ValueError` exception manually and ran the test suite using `python3 -m pytest tests/` to confirm backwards compatibility with existing methods.

---
*PR created automatically by Jules for task [9333410806060173766](https://jules.google.com/task/9333410806060173766) started by @zeyuz35*