### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure reflection in AdaptiveWeights

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Insecure Reflection in AdaptiveWeights]
+**Vulnerability:** The codebase uses `getattr(self, "_w" + self.weight_technique)` without validating the `weight_technique` string. An attacker could set `weight_technique` to arbitrary strings, allowing them to invoke any method that starts with `_w` on the object instance.
+**Learning:** Even internal library components must strictly validate parameters when using reflection (`getattr`, `eval`, etc.) to dynamically call methods based on user input, to prevent unauthorized method execution.
+**Prevention:** Validate `weight_technique` against an explicit allowlist in `_check_attributes` before calling it with `getattr`.

--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -24,6 +24,7 @@ GROUP_NONADAPTIVE = ["gl", "sgl"]
 GROUP_ADAPTIVE = ["agl", "asgl"]
 ALL_PENALTIES = INDIV_NONADAPTIVE + INDIV_ADAPTIVE + GROUP_ADAPTIVE + GROUP_NONADAPTIVE
 ALLOWED_MODELS = ["lm", "qr", "logit"]
+ALLOWED_WEIGHT_TECHNIQUES = ["pca_1", "pca_pct", "pls_1", "pls_pct", "sparse_pca", "unpenalized", "lasso", "ridge"]
 
 
 def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
@@ -697,6 +698,13 @@ class AdaptiveWeights:
         y: ArrayOrSparse,
         group_index: Optional[Sequence[int]] = None,
     ):
+        if not isinstance(self.weight_technique, str):
+            raise ValueError(f"weight_technique must be a string; got {type(self.weight_technique).__name__}.")
+        if self.weight_technique not in ALLOWED_WEIGHT_TECHNIQUES:
+            raise ValueError(
+                f"weight_technique must be one of {sorted(ALLOWED_WEIGHT_TECHNIQUES)}; got {self.weight_technique}."
+            )
+
         X, y = check_X_y(
             X,
             y,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `weight_technique` parameter was passed unvalidated into `getattr(self, "_w" + self.weight_technique)`, exposing an insecure reflection vulnerability where arbitrary methods starting with `_w` could be executed.
🎯 Impact: Attackers who can control the instantiation or hyperparameters of the estimator could bypass intended functionality or trigger arbitrary pre-existing internal components within the module.
🔧 Fix: Extracted a central `ALLOWED_WEIGHT_TECHNIQUES` allowlist and added rigorous type checking and exact match validation inside `AdaptiveWeights.fit_weights`.
✅ Verification: Exploit simulations now correctly fail with a `ValueError`. Pre-existing `asgl` test suite runs successfully with zero regressions. Journaled findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [344531639954829499](https://jules.google.com/task/344531639954829499) started by @zeyuz35*