### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure reflection via weight_technique attribute

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -24,6 +24,16 @@ GROUP_NONADAPTIVE = ["gl", "sgl"]
 GROUP_ADAPTIVE = ["agl", "asgl"]
 ALL_PENALTIES = INDIV_NONADAPTIVE + INDIV_ADAPTIVE + GROUP_ADAPTIVE + GROUP_NONADAPTIVE
 ALLOWED_MODELS = ["lm", "qr", "logit"]
+ALLOWED_WEIGHT_TECHNIQUES = [
+    "pca_1",
+    "pca_pct",
+    "pls_1",
+    "pls_pct",
+    "sparse_pca",
+    "unpenalized",
+    "lasso",
+    "ridge",
+]
 
 
 def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
@@ -694,6 +704,11 @@ class AdaptiveWeights:
         y: ArrayOrSparse,
         group_index: Optional[Sequence[int]] = None,
     ):
+        if not isinstance(self.weight_technique, str) or self.weight_technique not in ALLOWED_WEIGHT_TECHNIQUES:
+            raise ValueError(
+                f"weight_technique must be one of {sorted(ALLOWED_WEIGHT_TECHNIQUES)}; "
+                f"got {self.weight_technique}."
+            )
         X, y = check_X_y(
             X,
             y,

--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -24,7 +24,7 @@ GROUP_NONADAPTIVE = ["gl", "sgl"]
 GROUP_ADAPTIVE = ["agl", "asgl"]
 ALL_PENALTIES = INDIV_NONADAPTIVE + INDIV_ADAPTIVE + GROUP_ADAPTIVE + GROUP_NONADAPTIVE
 ALLOWED_MODELS = ["lm", "qr", "logit"]
-ALLOWED_WEIGHT_TECHNIQUES = [
+ALLOWED_WEIGHT_TECHNIQUES = {
     "pca_1",
     "pca_pct",
     "pls_1",
@@ -33,7 +33,7 @@ ALLOWED_WEIGHT_TECHNIQUES = [
     "unpenalized",
     "lasso",
     "ridge",
-]
+}
 
 
 def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -14,6 +14,7 @@ from sklearn.metrics import mean_squared_error
         dict(penalization="foo"),        # unsupported penalty
         dict(lambda1=-0.1),              # negative λ
         dict(alpha=1.5),                 # alpha outside [0, 1]
+        dict(penalization="alasso", weight_technique="foo"), # unsupported weight technique
     ],
 )
 def test_bad_constructor_arguments_raises(bad_kwargs):


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unvalidated user input `weight_technique` was being concatenated with `"_w"` and passed directly to `getattr(self, ...)` to dynamically invoke methods. This allowed arbitrary, potentially malicious attributes or methods (e.g. methods injected via inheritance or existing internal methods) to be accessed and executed during model fitting.
🎯 **Impact:** Exploitation of this insecure reflection could lead to unexpected behavior, logic bypass, or arbitrary code execution within the context of the running application.
🔧 **Fix:** Added an explicit allowlist `ALLOWED_WEIGHT_TECHNIQUES` (`pca_1`, `pca_pct`, `pls_1`, `pls_pct`, `sparse_pca`, `unpenalized`, `lasso`, `ridge`) and implemented strict validation in `AdaptiveWeights.fit_weights` to ensure `weight_technique` is explicitly permitted before invoking `getattr`.
✅ **Verification:** Verified that attempting to set an invalid or exploit `weight_technique` throws a `ValueError` immediately, and passing the local pytest test suite verifying this new behavior.

---
*PR created automatically by Jules for task [3326912522717261989](https://jules.google.com/task/3326912522717261989) started by @zeyuz35*