### PR TITLE
🛡️ Sentinel: [improvement] Add validation for canon_backend

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -34,6 +34,7 @@ ALLOWED_WEIGHT_TECHNIQUES = {
     "lasso",
     "ridge",
 }
+ALLOWED_CANON_BACKENDS = ("CPP", "SCIPY", "COO")
 
 
 def _get_group_info(group_index: np.ndarray) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
@@ -126,6 +127,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
         if (self.penalization is not None) and (self.penalization not in ALL_PENALTIES):
             raise ValueError(
                 f"penalization must be one of {sorted(ALL_PENALTIES)}; got {self.penalization}."
+            )
+        if not isinstance(self.canon_backend, str) or self.canon_backend not in ALLOWED_CANON_BACKENDS:
+            raise ValueError(
+                f"canon_backend must be one of {sorted(ALLOWED_CANON_BACKENDS)}; got {self.canon_backend}."
             )
 
     def _quantile_function(self, X) -> cp.Expression:


### PR DESCRIPTION
🛡️ Sentinel: [improvement]

💡 What:
Added an explicit allowlist validation (`ALLOWED_CANON_BACKENDS`) for the `canon_backend` parameter in `BaseModel`.

🎯 Why:
To prevent unsupported or potentially malicious values from being passed directly to the `cp.Problem.solve(canon_backend=...)` method. While primarily an improvement in configuration validation for a local ML library, enforcing explicit allowlists aligns with defensive programming standards to limit configuration surfaces.

✅ Verification:
Ran the test suite, which verified all existing `CPP` and standard `SCIPY`/`COO` tests continue to pass without regressions.

---
*PR created automatically by Jules for task [18108543513913303802](https://jules.google.com/task/18108543513913303802) started by @zeyuz35*