### PR TITLE
🛡️ Sentinel: [HIGH] Fix validation bypass in logistic regression target labels

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -379,20 +379,19 @@ class BaseModel(BaseEstimator, RegressorMixin):
         self._check_attributes()
         # Check binary y
         if self._estimator_type == "classifier":
-            if type_of_target(y) != "binary":
-                unique_y_values = np.unique(y)
-                # check_estimator might pass float y like [0.0, 1.0]
-                is_binary_int = len(unique_y_values) <= 2 and np.all(
-                    np.isin(unique_y_values, [0, 1])
+            unique_y_values = np.unique(y)
+            # check_estimator might pass float y like [0.0, 1.0]
+            is_binary_int = len(unique_y_values) <= 2 and np.all(
+                np.isin(unique_y_values, [0, 1])
+            )
+            is_binary_float = len(unique_y_values) <= 2 and np.all(
+                np.isin(unique_y_values, [0.0, 1.0])
+            )
+            if not (is_binary_int or is_binary_float):
+                raise ValueError(
+                    "For logistic model, y must contain only 0 and 1 (or 0.0, 1.0)."
                 )
-                is_binary_float = len(unique_y_values) <= 2 and np.all(
-                    np.isin(unique_y_values, [0.0, 1.0])
-                )
-                if not (is_binary_int or is_binary_float):
-                    raise ValueError(
-                        "For logistic model, y must contain only 0 and 1 (or 0.0, 1.0)."
-                    )
-                y = y.astype(int)
+            y = y.astype(int)
             self.classes_ = np.array([0, 1])  # Assuming 0 and 1 are the classes
         if (
             self.penalization in (GROUP_NONADAPTIVE + GROUP_ADAPTIVE)

--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -379,15 +379,8 @@ class BaseModel(BaseEstimator, RegressorMixin):
         self._check_attributes()
         # Check binary y
         if self._estimator_type == "classifier":
-            unique_y_values = np.unique(y)
-            # check_estimator might pass float y like [0.0, 1.0]
-            is_binary_int = len(unique_y_values) <= 2 and np.all(
-                np.isin(unique_y_values, [0, 1])
-            )
-            is_binary_float = len(unique_y_values) <= 2 and np.all(
-                np.isin(unique_y_values, [0.0, 1.0])
-            )
-            if not (is_binary_int or is_binary_float):
+            unique_y_values = set(np.unique(y))
+            if not (unique_y_values.issubset({0, 1}) or unique_y_values.issubset({0.0, 1.0})):
                 raise ValueError(
                     "For logistic model, y must contain only 0 and 1 (or 0.0, 1.0)."
                 )


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The classification target input validation in `asgl.skmodels.Regressor` relied on `sklearn.utils.multiclass.type_of_target(y) != "binary"` to gate strict validation of elements being `0` or `1`. However, `type_of_target` returns `"binary"` for any 2-element array (such as `[-1, 1]`, `[2, 5]`, or `["yes", "no"]`). This allowed arrays with unhandled values to bypass validation and bleed into the CVXPY solver logic.
🎯 **Impact:** If `[-1, 1]` or strings passed through validation to the `logit` solver, it corrupted the mathematically formulated negative log-likelihood objective:
`(-1.0 / y.shape[0]) * cp.sum(cp.multiply(y - 1, model_prediction) - cp.logistic(-model_prediction))`
With `y=-1`, `y-1` becomes `-2`, breaking fundamental solver bounds, returning undefined results (or `unbounded`/`infeasible` status depending on the backend solver) without correctly erroring out. It could also lead to silent mathematical errors when dealing with numeric floats.
🔧 **Fix:** Removed the `if type_of_target(y) != "binary":` condition. The verification that target elements exclusively contain `{0, 1}` or `{0.0, 1.0}` is now explicitly checked for all cases where `self._estimator_type == "classifier"`.
✅ **Verification:** Verified by throwing arrays such as `[-1, 1]` at the `model.fit(X, y)` function with `model='logit'`. Before the patch, the code attempted solving an invalid optimization problem. After the patch, it immediately raises a robust `ValueError` explaining that elements must be `0` or `1`. Also ran `pytest` locally to ensure unmodified code behavior was preserved.

---
*PR created automatically by Jules for task [3122585762926477070](https://jules.google.com/task/3122585762926477070) started by @zeyuz35*