### PR TITLE
🛡️ Sentinel: [security improvement] Validate adaptive weight numeric parameters

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -711,6 +711,21 @@ class AdaptiveWeights:
                 f"weight_technique must be one of {sorted(ALLOWED_WEIGHT_TECHNIQUES)}; "
                 f"got {self.weight_technique}."
             )
+        check_scalar(
+            self.weight_tol,
+            "weight_tol",
+            target_type=(int, float),
+            min_val=0.0,
+            include_boundaries="neither",
+        )
+        check_scalar(
+            self.variability_pct,
+            "variability_pct",
+            target_type=(int, float),
+            min_val=0.0,
+            max_val=1.0,
+            include_boundaries="right",
+        )
         X, y = check_X_y(
             X,
             y,


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Missing input validation on critical numeric hyperparameters (`weight_tol`, `variability_pct`) in `AdaptiveWeights.fit_weights`. A zero or negative `weight_tol` could lead to division by zero or negative weights during model fitting, bypassing the convex logic of the penalization and causing obscure mathematical errors.
🎯 Impact: Prevent unexpected application crashes or malformed mathematical outputs during model fitting when invalid configurations are supplied.
🔧 Fix: Used scikit-learn's `check_scalar` to enforce that `weight_tol` must be strictly positive (> 0.0) and `variability_pct` must be between 0.0 and 1.0.
✅ Verification: Ran the test suite using `source .venv/bin/activate && PYTHONPATH=. python3 -m pytest tests/` which passed cleanly, proving no regressions are introduced.

---
*PR created automatically by Jules for task [13585464129554338055](https://jules.google.com/task/13585464129554338055) started by @zeyuz35*