### PR TITLE
🛡️ Sentinel: [MEDIUM] Add defensive hyperparameter validation for AdaptiveWeights

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -711,6 +711,21 @@ class AdaptiveWeights:
                 f"weight_technique must be one of {sorted(ALLOWED_WEIGHT_TECHNIQUES)}; "
                 f"got {self.weight_technique}."
             )
+        check_scalar(
+            self.weight_tol,
+            "weight_tol",
+            target_type=(int, float),
+            min_val=0.0,
+            include_boundaries="neither",
+        )
+        check_scalar(
+            self.variability_pct,
+            "variability_pct",
+            target_type=(int, float),
+            min_val=0.0,
+            max_val=1.0,
+            include_boundaries="right",
+        )
         X, y = check_X_y(
             X,
             y,

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -906,6 +906,21 @@ def test_predict():
                                    err_msg='Failed prediction and / or metric computation')
 
 
+def test_error_weight_tol_zero():
+    X = np.array([[1.0, 0.0], [0.0, 1.0]])
+    y = np.array([1.0, 0.0])
+    # Setting weight_tol to 0.0 or below should raise an error
+    model = Regressor(model='lm', penalization='alasso', weight_technique='unpenalized', weight_tol=0.0)
+    with pytest.raises(ValueError, match="weight_tol == 0.0, must be > 0.0"):
+        model.fit(X, y)
+
+def test_error_variability_pct_invalid():
+    X = np.array([[1.0, 0.0], [0.0, 1.0]])
+    y = np.array([1.0, 0.0])
+    model = Regressor(model='lm', penalization='alasso', weight_technique='pca_pct', variability_pct=1.5)
+    with pytest.raises(ValueError, match="variability_pct == 1.5, must be <= 1.0"):
+        model.fit(X, y)
+
 def test_grid_search():
     data = np.loadtxt('data.csv', delimiter=",", dtype=float)
     X = data[:, :-1]


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Unvalidated input parameters (`weight_tol`, `variability_pct`) in `AdaptiveWeights.fit_weights` could lead to unhandled exceptions or math domain errors (e.g., ZeroDivisionError when `weight_tol` is set to `0.0` or less). While this is a local ML library, failing securely via upfront validation is a core defense-in-depth practice.
**🎯 Impact:** Users or automated systems repeatedly feeding unvalidated inputs to the model could cause unanticipated crashes during runtime.
**🔧 Fix:** Added strict boundary validation using `check_scalar` from `sklearn.utils.validation` for `weight_tol` (must be `> 0.0`) and `variability_pct` (must be `<= 1.0` and `>= 0.0`) inside the `fit_weights` method. Added unit tests for these boundaries and cleaned up testing artifacts.
**✅ Verification:** The new tests `test_error_weight_tol_zero` and `test_error_variability_pct_invalid` pass, confirming validation is actively preventing the vulnerabilities.

---
*PR created automatically by Jules for task [13486054741986852833](https://jules.google.com/task/13486054741986852833) started by @zeyuz35*