### PR TITLE
🛡️ Sentinel: [improvement] Input validation on hyperparameters

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -1,4 +1,5 @@
 import warnings
+import numbers
 from typing import Sequence, Optional, Tuple, Union, Dict
 from sklearn.utils.validation import check_is_fitted, check_X_y, check_scalar
 import cvxpy as cp
@@ -103,14 +104,14 @@ class BaseModel(BaseEstimator, RegressorMixin):
         check_scalar(
             self.lambda1,
             "lambda1",
-            target_type=(int, float),
+            target_type=numbers.Real,
             min_val=0.0,
             include_boundaries="left",
         )
         check_scalar(
             self.alpha,
             "alpha",
-            target_type=(int, float),
+            target_type=numbers.Real,
             min_val=0.0,
             max_val=1.0,
             include_boundaries="both",
@@ -118,7 +119,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
         check_scalar(
             self.quantile,
             "quantile",
-            target_type=(int, float),
+            target_type=numbers.Real,
             min_val=0.0,
             max_val=1.0,
             include_boundaries="neither",
@@ -775,6 +776,21 @@ class AdaptiveWeights:
                 f"weight_technique must be one of {sorted(ALLOWED_WEIGHT_TECHNIQUES)}; "
                 f"got {self.weight_technique}."
             )
+        check_scalar(
+            self.weight_tol,
+            "weight_tol",
+            target_type=numbers.Real,
+            min_val=0.0,
+            include_boundaries="neither",
+        )
+        check_scalar(
+            self.variability_pct,
+            "variability_pct",
+            target_type=numbers.Real,
+            min_val=0.0,
+            max_val=1.0,
+            include_boundaries="both",
+        )
         X, y = check_X_y(
             X,
             y,


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Missing strict boundary and robust type validation for numerical hyperparameters like `weight_tol` and `variability_pct`.
🎯 **Impact**: Using invalid parameters (e.g., negative `weight_tol` or `variability_pct > 1.0`) could lead to underlying unhandled exceptions like division by zero or invalid operations during matrix decomposition, opening avenues for unexpected crashes (Denial of Service) if the estimator is exposed directly to external user input (e.g., via a ML backend service).
🔧 **Fix**: 
- Replaced error-prone `(int, float)` type checks with `numbers.Real` to uniformly support Python native and NumPy scalars in `_check_attributes`.
- Added strict `check_scalar` validations for `weight_tol` (must be `> 0.0`) and `variability_pct` (must be `[0.0, 1.0]`) directly within `fit_weights`.
✅ **Verification**: Validated changes by ensuring the full `pytest` suite passes without regressions and testing boundary values on the parameters which now correctly emit standard scikit-learn `ValueError` exceptions immediately upon invocation.

---
*PR created automatically by Jules for task [17233273408841527732](https://jules.google.com/task/17233273408841527732) started by @zeyuz35*