### PR TITLE
🛡️ Sentinel: [improvement] Validate numeric bounds for weight_tol and variability_pct

### DIFF
--- a/asgl/skmodels.py
+++ b/asgl/skmodels.py
@@ -2,6 +2,7 @@ import warnings
 from typing import Sequence, Optional, Tuple, Union, Dict
 from sklearn.utils.validation import check_is_fitted, check_X_y, check_scalar
 import cvxpy as cp
+import numbers
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.cross_decomposition import PLSRegression
@@ -767,6 +768,21 @@ class AdaptiveWeights:
         y: ArrayOrSparse,
         group_index: Optional[Sequence[int]] = None,
     ):
+        check_scalar(
+            self.weight_tol,
+            "weight_tol",
+            target_type=numbers.Real,
+            min_val=0.0,
+            include_boundaries="neither",
+        )
+        check_scalar(
+            self.variability_pct,
+            "variability_pct",
+            target_type=numbers.Real,
+            min_val=0.0,
+            max_val=1.0,
+            include_boundaries="right",
+        )
         if (
             not isinstance(self.weight_technique, str)
             or self.weight_technique not in ALLOWED_WEIGHT_TECHNIQUES

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -18,6 +18,10 @@ from sklearn.metrics import mean_squared_error
         dict(
             penalization="alasso", weight_technique="foo"
         ),  # unsupported weight technique
+        dict(penalization="alasso", weight_tol=0.0), # weight_tol must be > 0.0
+        dict(penalization="alasso", weight_tol=-1.0), # weight_tol must be > 0.0
+        dict(penalization="alasso", variability_pct=1.5), # variability_pct must be in (0, 1]
+        dict(penalization="alasso", variability_pct=0.0), # variability_pct must be in (0, 1]
     ],
 )
 def test_bad_constructor_arguments_raises(bad_kwargs):


### PR DESCRIPTION
🚨 Severity: LOW / MEDIUM (Defense in depth)
💡 Vulnerability: Missing domain boundary validation for numeric hyperparameters in adaptive weight estimation (`weight_tol`, `variability_pct`). A `weight_tol` of `0.0` or less could trigger `ZeroDivisionError` deeper within the numeric fitting pipeline since it's used as a denominator offset. A `variability_pct` outside `(0.0, 1.0]` leads to invalid PCA/PLS variance thresholds.
🎯 Impact: Prevent unexpected runtime crashes and undefined behavior by throwing explicit `ValueError` early before hitting internal dependencies.
🔧 Fix: Add `check_scalar(..., target_type=numbers.Real, min_val=0.0, include_boundaries="neither")` for `weight_tol` and `include_boundaries="right"` for `variability_pct` inside `asgl.skmodels.AdaptiveWeights.fit_weights`.
✅ Verification: Covered with `pytest` unit tests in `tests/test_skmodels.py::test_bad_constructor_arguments_raises`. All 115 tests passed perfectly.

---
*PR created automatically by Jules for task [9016443231874359397](https://jules.google.com/task/9016443231874359397) started by @zeyuz35*