### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing validation for weight_tol and variability_pct causing division by zero

### DIFF
--- a/asgl/adaptive_weights.py
+++ b/asgl/adaptive_weights.py
@@ -1,6 +1,7 @@
 import warnings
+import numbers
 from typing import Sequence, Optional, Tuple, Union
-from sklearn.utils.validation import check_X_y
+from sklearn.utils.validation import check_X_y, check_scalar
 import numpy as np
 from sklearn.cross_decomposition import PLSRegression
 from sklearn.decomposition import PCA
@@ -286,6 +287,21 @@ class AdaptiveWeights:
     y: ArrayOrSparse,
     group_index: Optional[Sequence[int]] = None,
   ):
+    check_scalar(
+      self.weight_tol,
+      "weight_tol",
+      target_type=numbers.Real,
+      min_val=0.0,
+      include_boundaries="neither",
+    )
+    check_scalar(
+      self.variability_pct,
+      "variability_pct",
+      target_type=numbers.Real,
+      min_val=0.0,
+      max_val=1.0,
+      include_boundaries="both",
+    )
     if (
       not isinstance(self.weight_technique, str)
       or self.weight_technique not in ALLOWED_WEIGHT_TECHNIQUES


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input validation on numeric hyper-parameters (`weight_tol`, `variability_pct`) within the `AdaptiveWeights` class could lead to unexpected unhandled math domain errors. In particular, a `weight_tol` of `0.0` allows division by zero during adaptive weight inversions.
🎯 Impact: Denial-of-Service via unexpected runtime crashes when creating CVXPY solver problems.
🔧 Fix: Validated boundary types and ranges using scikit-learn standard `check_scalar`.
✅ Verification: The test suite passes fully, and local tests successfully reject `0.0` for `weight_tol` with a descriptive ValueError.

---
*PR created automatically by Jules for task [1832546014553894543](https://jules.google.com/task/1832546014553894543) started by @zeyuz35*