### PR TITLE
🛡️ Sentinel: [improvement] Add strict numerical input validation for hyperparameters

### DIFF
--- a/asgl/adaptive_weights.py
+++ b/asgl/adaptive_weights.py
@@ -1,7 +1,8 @@
 import warnings
 from typing import Sequence, Optional, Tuple, Union
-from sklearn.utils.validation import check_X_y
+from sklearn.utils.validation import check_X_y, check_scalar
 import numpy as np
+import numbers
 from sklearn.cross_decomposition import PLSRegression
 from sklearn.decomposition import PCA
 from sklearn.decomposition import SparsePCA
@@ -286,6 +287,38 @@ class AdaptiveWeights:
     y: ArrayOrSparse,
     group_index: Optional[Sequence[int]] = None,
   ):
+    check_scalar(
+      self.individual_power_weight,
+      "individual_power_weight",
+      target_type=numbers.Real,
+    )
+    check_scalar(
+      self.group_power_weight,
+      "group_power_weight",
+      target_type=numbers.Real,
+    )
+    check_scalar(
+      self.variability_pct,
+      "variability_pct",
+      target_type=numbers.Real,
+      min_val=0.0,
+      max_val=1.0,
+      include_boundaries="both",
+    )
+    check_scalar(
+      self.weight_tol,
+      "weight_tol",
+      target_type=numbers.Real,
+      min_val=0.0,
+      include_boundaries="neither",
+    )
+    check_scalar(
+      self.lambda1_weights,
+      "lambda1_weights",
+      target_type=numbers.Real,
+      min_val=0.0,
+      include_boundaries="left",
+    )
     if (
       not isinstance(self.weight_technique, str)
       or self.weight_technique not in ALLOWED_WEIGHT_TECHNIQUES

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -3,6 +3,7 @@ from typing import Sequence, Optional, Tuple, Union
 from sklearn.utils.validation import check_is_fitted, check_X_y, check_scalar
 import cvxpy as cp
 import numpy as np
+import numbers
 from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
@@ -64,14 +65,14 @@ class BaseModel(BaseEstimator, RegressorMixin):
     check_scalar(
       self.lambda1,
       "lambda1",
-      target_type=(int, float),
+      target_type=numbers.Real,
       min_val=0.0,
       include_boundaries="left",
     )
     check_scalar(
       self.alpha,
       "alpha",
-      target_type=(int, float),
+      target_type=numbers.Real,
       min_val=0.0,
       max_val=1.0,
       include_boundaries="both",
@@ -79,7 +80,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     check_scalar(
       self.quantile,
       "quantile",
-      target_type=(int, float),
+      target_type=numbers.Real,
       min_val=0.0,
       max_val=1.0,
       include_boundaries="neither",


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Missing rigorous input validation for hyperparameters across model initialization and weight calculation paths.
🎯 Impact: Using incorrect numerical types (like strings instead of floats) or invalid bounds (like negative `variability_pct`) might bypass Python type checking but result in division-by-zero math errors, infinite weights, or unhandled crashes deep within CVXPY or SciPy routines, acting as a minor DoS vector or creating unexpected behavior.
🔧 Fix: Added strict checks using `sklearn.utils.validation.check_scalar` mapping to `numbers.Real` inside `BaseModel._check_attributes()` and `AdaptiveWeights.fit_weights()`.
✅ Verification: `pytest tests/` was executed successfully to ensure validation bounds matched model specifications and no legitimate parameters were rejected.

---
*PR created automatically by Jules for task [77743242117725480](https://jules.google.com/task/77743242117725480) started by @zeyuz35*