### PR TITLE
📦 Binder: Move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2025-05-10 - Import Libraries Inside Method Definitions
+**Learning:** `ClassifierTags` and `RegressorTags` from `sklearn.utils._tags` were imported locally inside the `__sklearn_tags__` method definition of `asgl/base_model.py`, violating the rule against importing libraries inside function/method definitions.
+**Action:** Move local imports to module level at the top of the file to adhere to PEP 8 standards and ensure dependencies are explicitly declared up-front.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,7 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+from sklearn.utils._tags import ClassifierTags, RegressorTags
 
 from .constants import (
   ArrayOrSparse,
@@ -423,13 +424,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
📦 Binder: Move scikit-learn tags imports to module level

Moved `ClassifierTags` and `RegressorTags` imports from inside the `__sklearn_tags__` method definition to the top of `asgl/base_model.py` to adhere to standard maintainability practices and explicitly declare dependencies upfront. Created `.jules/binder.md` to document the learning.

---
*PR created automatically by Jules for task [16554494134642128502](https://jules.google.com/task/16554494134642128502) started by @zeyuz35*