### PR TITLE
🗃️ Curator: fix silent loss of DataFrame column names metadata

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-10 - Pandas dataframe column name preservation bug
+**Learning:** `asgl.base_model.BaseModel.fit` attempts to preserve feature names when fitting a model by checking `hasattr(X, 'columns') and callable(getattr(X, 'columns', None))`. However, Pandas DataFrame `columns` is a property/Index object, not a callable method. This causes the `feature_names_in_` attribute to silently remain `None` instead of capturing the column names, resulting in a loss of metadata.
+**Action:** Remove the `callable()` check when attempting to retrieve column names from objects like DataFrames, as properties are not callable but still contain the valid feature name metadata.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns"):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
🎯 What
This PR removes a flawed `callable()` check when extracting `feature_names_in_` from input data structures like Pandas DataFrames.

💡 Why
In `asgl.base_model.BaseModel.fit`, the code attempted to capture feature names using `if hasattr(X, "columns") and callable(getattr(X, "columns", None)):`. However, Pandas DataFrame `columns` is an `Index` property, not a callable method. Because it is not callable, the check evaluates to `False`, causing the column names (metadata) to be silently dropped and leaving `feature_names_in_ = None`. 

✅ Verification
A test was run to fit the model on a Pandas DataFrame, and `model.feature_names_in_` was verified to successfully capture the column names as `['f1' 'f2']` instead of returning `None`. The full test suite was executed via pytest, and all 111 tests passed successfully.

✨ Result
Input metadata (feature/column names) is now correctly preserved and attached to the model instance during `fit`, preventing silent data loss and enhancing type stability and compatibility with standard data formats.

---
*PR created automatically by Jules for task [355485675491737231](https://jules.google.com/task/355485675491737231) started by @zeyuz35*