### PR TITLE
📦 Binder: [dependency/structure improvement] Move inline imports and clean up tests

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - Move method-level imports to module level
+**Learning:** In `asgl/base_model.py`, `sklearn.utils._tags.ClassifierTags` and `sklearn.utils._tags.RegressorTags` were imported inside the `__sklearn_tags__` method definition. This violates standard Python style conventions and rules against importing libraries inside function/method definitions.
+**Action:** When auditing files, search for inline imports within methods and move them to the top of the file alongside other module-level imports.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,7 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+from sklearn.utils._tags import ClassifierTags, RegressorTags
 
 from .constants import (
   ArrayOrSparse,
@@ -423,13 +424,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1816,14 +1816,13 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -2024,7 +2024,6 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
🎯 What
This PR implements small, targeted structural improvements to the codebase:
- Resolves an inline method dependency by moving `from sklearn.utils._tags import ClassifierTags, RegressorTags` from the `__sklearn_tags__` method out to the module level in `asgl/base_model.py`. 
- Cleans up several unused dependencies and variables within the test suite (`tests/test_leakage.py`, `tests/test_skmodels.py`, `tests/test_skmodels_sparse.py`, and `tests/test_solver_fallback.py`).

💡 Why
Inline imports violate standard Python dependency formatting and make dependencies hidden or harder to manage. Removing unused dependencies and dead variable assignments maintains a lean, clean test suite.

✅ Verification
Ran the `ruff check` linting and the `pytest tests/` test suite and confirmed 111 out of 111 tests pass successfully with no errors or regressions.

---
*PR created automatically by Jules for task [3667669267665096365](https://jules.google.com/task/3667669267665096365) started by @zeyuz35*