### PR TITLE
📝 Docent: Fix documentation style in parameter descriptions

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-10 - Fix wording in docstring
+**Learning:** Found informal/weird wording in docstrings. "If this parameter is informed" and an extra dot with ".".
+**Action:** Replaced with "If provided," and fixed the punctuation.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -80,12 +80,12 @@ class Regressor(BaseModel, AdaptiveWeights):
   spca_ridge_alpha: float, default=1e-2
       sparse PCA parameter. See sklearn implementation of sparse PCA for more details.
   individual_weights: array or None, default=None
-      An array containing the values of individual weights in adaptive penalizations. If this parameter is informed,
+      An array containing the values of individual weights in adaptive penalizations. If provided,
       it overrides the weight estimation process defined by parameter ``weight_technique`` and allows the user to
       provide custom weights.
   group_weights: array or None, default=None
-      An array containing the values of group weights in adaptive penalizations. If this parameter is informed,
-      it overrides the weight estimation process defined by parameter ``weight_technique``. and allows the user to
+      An array containing the values of group weights in adaptive penalizations. If provided,
+      it overrides the weight estimation process defined by parameter ``weight_technique`` and allows the user to
       provide custom weights.
   tol: float, default=1e-3
       The tolerance for a coefficient in the model to be considered as 0. Values smaller than ``tol`` are assumed to

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1823,7 +1823,7 @@ def test_errors():
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
🎯 What:
- Fixed informal wording in the parameter descriptions for `individual_weights` and `group_weights` in `asgl/regressor.py`, replacing "If this parameter is informed," with "If provided,".
- Removed an extra period in the docstring for `weight_technique` in `asgl/regressor.py`.
- Added an entry to `.jules/docent.md`.

💡 Why:
- To adhere to professional, terse wording and correct minor grammatical and formatting inconsistencies in the API documentation.

✅ Verification:
- Ran `ruff check`.
- Ran full `pytest` suite. All 111 tests pass with no new regressions.

✨ Result:
- Clearer, professional parameter descriptions.

---
*PR created automatically by Jules for task [16549363661364522158](https://jules.google.com/task/16549363661364522158) started by @zeyuz35*