### PR TITLE
🗃️ Curator: Fix dataframe columns attribute preservation

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2025-02-24 - Pandas DataFrame feature name preservation
+**Learning:** `DataFrame.columns` is a pandas Index object (an iterable property), not a callable method. Using `callable(getattr(X, "columns", None))` evaluates to False, causing feature names to be silently discarded.
+**Action:** When extracting properties like `columns` from dataframes, check for the attribute's existence using `hasattr(X, "columns")` rather than verifying it's a callable. Ensure attributes correctly preserve their original types and arrays are correctly wrapped into standard formats (`np.asarray`) without discarding metadata due to flawed detection logic.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns"):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
🗃️ Curator: Fix dataframe columns attribute preservation

**🎯 What:**
Modified the `feature_names_in_` extraction logic in `BaseModel.fit` to correctly identify and capture the `.columns` attribute of Pandas DataFrames.

**💡 Why:**
The original check `hasattr(X, "columns") and callable(getattr(X, "columns", None))` evaluates to `False` because `DataFrame.columns` is a property (a `pandas.Index` object), not a callable method. This caused feature names to be silently discarded during data ingestion, resulting in data/metadata loss.

**✅ Verification:**
- Created a specific custom test script to verify that `model.feature_names_in_` captures the column labels correctly.
- Ran all existing unit tests with `pytest` - all tests pass.
- Ran the linter with `ruff check` - code passes formatting checks.

**✨ Result:**
The `feature_names_in_` attribute accurately reflects the input dataframe's columns without erroneously checking for callability, successfully preserving the metadata as expected.

---
*PR created automatically by Jules for task [18129418657851104798](https://jules.google.com/task/18129418657851104798) started by @zeyuz35*