### PR TITLE
📦 Binder: Move method imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Avoid importing in method definition
+**Learning:** Found an `import` statement for `ClassifierTags` and `RegressorTags` within the `__sklearn_tags__` method. This violates the "Never import libraries inside function/method definitions" rule.
+**Action:** Move the `import` statements to the module level and fix the usage.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,10 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
 
 from .constants import (
   ArrayOrSparse,
@@ -423,13 +427,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1816,14 +1816,13 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -2024,7 +2024,6 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
**🎯 What**
Moved the `from sklearn.utils._tags import ClassifierTags, RegressorTags` imports in `asgl/base_model.py` from inside the `__sklearn_tags__` method definition to the top module level, wrapped in a `try...except ImportError` block to preserve scikit-learn backward compatibility. Also cleaned up some unused variables and imports in tests.

**💡 Why**
Having imports nested inside method definitions is an anti-pattern. Moving them to the module level improves readability, performance, and complies with package hygiene best practices. The `try...except` maintains compatibility for environments with older `scikit-learn` versions that don't have this API.

**✅ Verification**
- Ran `ruff check asgl/` - All checks passed.
- Ran `pytest tests/test_skmodels.py` - All tests passed.

**✨ Result**
The file now adheres to cleaner code structure and dependency tracking practices without sacrificing backward compatibility.

---
*PR created automatically by Jules for task [8919277767711862032](https://jules.google.com/task/8919277767711862032) started by @zeyuz35*