### PR TITLE
📦 Binder: Refactor inline method imports to module level

### DIFF
--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,14 +428,16 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      try:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
+      except NameError:
+        pass
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      try:
+        tags.regressor_tags = RegressorTags()
+      except NameError:
+        pass
     return tags
 
   def _more_tags(self):

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1823,7 +1823,7 @@ def test_errors():
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
🎯 What
- Moved `from sklearn.utils._tags import ClassifierTags, RegressorTags` to the module level in `asgl/base_model.py`.
- Wrapped module-level import in `try/except ImportError` for compatibility with older scikit-learn versions.
- Cleaned up unused `pytest` and `numpy` imports in test files.
- Removed unnecessary f-string formatting in `tests/test_skmodels.py`.

💡 Why
- Adheres to the "Never do: Import libraries inside function/method definitions" rule for package hygiene.
- Reduces dependency footprint on tests where variables and imports were unused.
- Fails safely on older versions of dependencies without crashing module load.

✅ Verification
- Verified all 111 tests pass successfully via `pytest tests/`.
- Verified `ruff check asgl/` passes indicating the main package tree is clean.

✨ Result
- Cleaner, more standard top-level dependency loading.
- Improved code hygiene and linting results.

---
*PR created automatically by Jules for task [7274050443478463976](https://jules.google.com/task/7274050443478463976) started by @zeyuz35*