### PR TITLE
📝 Docent: Fix docstring formatting and typos in Regressor

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - [Docstring typos]
+**Learning:** Found typo 'defaul=0.1' in asgl/regressor.py. I should check other files for similar typos.
+**Action:** Fix typo and verify parameter docstrings in asgl/regressor.py and other files.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -16,14 +16,14 @@ class Regressor(BaseModel, AdaptiveWeights):
   """
   Parameters
   ----------
-  model: str, default = 'lm'
+  model: str, default='lm'
       Model to be fit. Currently, accepts:
           - 'lm': linear regression models.
           - 'qr': quantile regression models.
           - 'logit': logistic regression for binary classification, output binary classification.
       Both 'lm' and 'qr' models support multivariate regression (multiple outputs),
       allowing for simultaneous fitting and coupled feature selection with grouped penalizations.
-  penalization: str or None, default = 'lasso'
+  penalization: str or None, default='lasso'
       Penalization to use. Currently, accepts:
           - None: unpenalized model.
           - 'lasso': lasso penalization.
@@ -39,7 +39,7 @@ class Regressor(BaseModel, AdaptiveWeights):
       ``model='qr'``
   fit_intercept: bool, default=True,
       Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations.
-  lambda1: float, defaul=0.1
+  lambda1: float, default=0.1
       Constant that multiplies the penalization, controlling the strength. Must be a non-negative float
       i.e. in `[0, inf)`. Larger values will result in larger penalizations.
   alpha: float, default=0.5

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1823,7 +1823,7 @@ def test_errors():
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
🎯 What
Fixes a small typo (`defaul=0.1` -> `default=0.1`) and inconsistent spacing in the docstrings for the `Regressor` class parameters in `asgl/regressor.py`. Creates the `.jules/docent.md` journal file.

💡 Why
Improves readability and consistency of the public API documentation. The typo in `lambda1` could trip up automated documentation generation tools or confuse users.

✅ Verification
Ran `ruff check` and `pytest tests/` locally to confirm the changes are strictly cosmetic and introduce no functional regressions.

✨ Result
Cleaner, standardized docstrings for the `Regressor` class.

---
*PR created automatically by Jules for task [18217119728032953206](https://jules.google.com/task/18217119728032953206) started by @zeyuz35*