### PR TITLE
🗃️ Curator: Fix pandas feature names preservation in BaseModel.fit

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fix DataFrame Feature Names Extraction
+**Learning:** `callable(getattr(X, "columns", None))` fails for pandas DataFrames because `.columns` is a property returning an `Index` object, which is not callable.
+**Action:** Use `hasattr(X, "columns")` instead of `callable(...)` when checking if an object has a `columns` attribute to extract feature names.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns"):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
🎯 What
Fixed a data metadata preservation bug in `BaseModel.fit` where feature names (`feature_names_in_`) from Pandas DataFrames were being silently discarded.

💡 Why
The previous code checked `hasattr(X, "columns") and callable(getattr(X, "columns", None))`. For pandas DataFrames, `X.columns` returns a pandas `Index` object, which is not callable. Therefore, this check always failed for DataFrames, and the original feature names were lost (i.e. `feature_names_in_` remained `None`) before `check_X_y` converted the DataFrame to a NumPy array. By changing the check to simply `hasattr(X, "columns")`, we properly extract the column names.

✅ Verification
Ran a test patch demonstrating that the feature names are correctly captured from dummy Pandas-like structures, and confirmed that the standard pytest suite succeeds (`111 passed`).

✨ Result
Dataframes' column names are correctly preserved in the `feature_names_in_` attribute as expected, adhering to data integrity principles.

---
*PR created automatically by Jules for task [18398674072841186066](https://jules.google.com/task/18398674072841186066) started by @zeyuz35*