### PR TITLE
📝 Docent: fix typo in lambda1 parameter docstring

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2026-05-14 - Fix spelling error in docstring
+**Learning:** Found a spelling error "defaul=0.1" in `asgl/regressor.py` docstring.
+**Action:** Replace "defaul=" with "default=" to ensure formatting consistency in docstrings and follow standard presentation.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -39,7 +39,7 @@ class Regressor(BaseModel, AdaptiveWeights):
       ``model='qr'``
   fit_intercept: bool, default=True,
       Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations.
-  lambda1: float, defaul=0.1
+  lambda1: float, default=0.1
       Constant that multiplies the penalization, controlling the strength. Must be a non-negative float
       i.e. in `[0, inf)`. Larger values will result in larger penalizations.
   alpha: float, default=0.5


### PR DESCRIPTION
📝 Docent: documentation fix

**What:** Corrected spelling error (`defaul` -> `default`) in `lambda1` parameter docstring in `asgl/regressor.py`.
**Why:** Improves professional presentation and formatting consistency of public APIs.
**Verification:** Ran `ruff check` and `pytest`. No regressions or side effects.

---
*PR created automatically by Jules for task [989037637172534625](https://jules.google.com/task/989037637172534625) started by @zeyuz35*