### PR TITLE
🗃️ Curator: [data integrity/type stability fix]

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Fix Feature Names Preservation Bug
+**Learning:** `callable(getattr(X, 'columns', None))` fails silently for Pandas DataFrames because `columns` is a Pandas `Index` property, not a callable method, resulting in `feature_names_in_` never being preserved.
+**Action:** Use `hasattr(X, 'columns')` to verify the presence of column metadata without checking if it is callable. When testing Pandas interaction without requiring Pandas as a dependency, use a mock object returning an array from `__array__` with shape, ndim, and the required `columns` attribute.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns"):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -465,7 +465,7 @@ def test_gl_qr():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.8, lambda1=0, solver="CLARABEL"
@@ -648,7 +648,7 @@ def test_sgl_qr():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="sgl", quantile=0.8, lambda1=0, solver="CLARABEL"
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 
@@ -1945,6 +1945,27 @@ def test_grid_search():
         assert expected_output.get(key) == value, (
             f"Expected {key} to be {value}, but got {expected_output.get(key)}"
         )
+
+
+def test_feature_names_preserved():
+    class MockDataFrame:
+        def __init__(self, data, columns):
+            self.data = data
+            self.columns = columns
+            self.shape = data.shape
+            self.ndim = data.ndim
+
+        def __array__(self):
+            return self.data
+
+    X = MockDataFrame(np.random.randn(10, 3), columns=["a", "b", "c"])
+    y = np.random.randn(10)
+
+    model = Regressor(model="lm", penalization="lasso")
+    model.fit(X, y)
+
+    assert model.feature_names_in_ is not None
+    assert list(model.feature_names_in_) == ["a", "b", "c"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 What
Fixed a bug in `asgl/base_model.py` where feature names (columns) from Pandas DataFrames were not preserved in the `feature_names_in_` attribute.

💡 Why
The code previously checked if `X.columns` was callable. For Pandas DataFrames, `columns` is a property (an `Index` object), so the check silently failed, resulting in `feature_names_in_` always being `None`. As Curator, preserving metadata and attributes correctly without silent loss is priority.

✅ Verification
- Added a targeted test `test_feature_names_preserved` using a mock DataFrame to ensure columns are correctly captured and stored in `model.feature_names_in_`.
- Ran full test suite via `pytest` to confirm no regressions.
- Ran `ruff check` linters to clean up unused variables in test files.

✨ Result
Data metadata like dataframe column names are correctly retained during model `.fit()`.

---
*PR created automatically by Jules for task [9524399984967521452](https://jules.google.com/task/9524399984967521452) started by @zeyuz35*