### PR TITLE
📦 Binder: Extract sklearn tags and clean test imports

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,7 @@
+## 2024-05-15 - Extract sklearn tags to module level
+**Learning:** scikit-learn tags imported inside functions (like `__sklearn_tags__`) can be safely extracted to the module level.
+**Action:** Always wrap module-level scikit-learn imports in `try...except ImportError` blocks to ensure compatibility with older versions, and use `try...except NameError` inside functions.
+
+## 2024-05-15 - Remove unused imports in test files
+**Learning:** Unused imports in test files (like `pytest` or `numpy`) create unnecessary dependencies. Unused test variables (like `group_index` to test error messages) shouldn't be blindly deleted by sed or autofixers.
+**Action:** Use targeted `# noqa: F841` statements to disable linters for specifically unused variables meant for testing purposes to prevent them from being purged or triggering linting errors.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -18,6 +18,11 @@ from .constants import (
 )
 from .utils import _get_group_info
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 
 class BaseModel(BaseEstimator, RegressorMixin):
   """
@@ -423,14 +428,16 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      try:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
+      except NameError:
+        pass
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      try:
+        tags.regressor_tags = RegressorTags()
+      except NameError:
+        pass
     return tags
 
   def _more_tags(self):

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -2024,7 +2024,7 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
This PR fulfills the Binder persona's objective to improve package hygiene by making several small, targeted structural updates:

1. **Extracted imports:** Lifted inline `sklearn.utils._tags` imports out of `__sklearn_tags__` in `asgl/base_model.py`. Wrapped the module-level imports in a `try...except ImportError` block and instances in `try...except NameError` blocks to ensure compatibility with older `scikit-learn` versions.
2. **Removed unused test imports:** Removed an unused `pytest` import in `tests/test_leakage.py` and an unused `numpy` import in `tests/test_solver_fallback.py`.
3. **Fixed unused variable warnings:** Appended `# noqa: F841` to `group_index` in `tests/test_skmodels.py` and `tests/test_skmodels_sparse.py` to satisfy linters without altering test behavior.

These changes clarify the module dependencies, resolve lingering linter warnings, and keep the testing environment lean.

---
*PR created automatically by Jules for task [16005442204770195469](https://jules.google.com/task/16005442204770195469) started by @zeyuz35*