### PR TITLE
🗃️ Curator: [data integrity/type stability fix] Preserve DataFrame feature names

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-27 - Fix Pandas DataFrame metadata preservation in BaseModel.fit
+**Learning:** `BaseModel.fit` incorrectly checks `callable(getattr(X, "columns", None))` when trying to extract feature names from a Pandas DataFrame. `columns` is an `Index` object in Pandas (which is not callable), not a method. Because of this, `self.feature_names_in_` is set to `None` and feature names are silently lost.
+**Action:** Remove the `callable()` check. Just checking `hasattr(X, "columns")` is sufficient to determine if the object has a `columns` attribute to extract feature names from.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns"):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
🎯 What
`BaseModel.fit` silently dropped Pandas DataFrame column names (`feature_names_in_`) because it incorrectly checked if `DataFrame.columns` is callable.

💡 Why
In Pandas, `DataFrame.columns` is an `Index` attribute, not a method. Thus `callable(getattr(X, "columns", None))` always evaluated to `False` on DataFrames, losing valuable metadata and negatively impacting interoperability with downstream scikit-learn display logic.

✅ Verification
Removed the `callable()` check and verified via tests that `BaseModel` now properly extracts and stores `feature_names_in_` when fitted with an object possessing a `columns` attribute.

✨ Result
Data metadata (feature names) is correctly preserved when fitting the model, aligning with scikit-learn standard behavior.

---
*PR created automatically by Jules for task [13778315610592699563](https://jules.google.com/task/13778315610592699563) started by @zeyuz35*