### PR TITLE
📦 Binder: Move ClassifierTags and RegressorTags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Method-level dependencies wrapped in module level blocks
+**Learning:** scikit-learn tags (`ClassifierTags`, `RegressorTags`) were imported inside `__sklearn_tags__` in `base_model.py`. Moving these imports to the module level allows `scikit-learn` imports to happen centrally, improving readability and structure, while maintaining backwards-compatibility via `try...except ImportError: pass`.
+**Action:** Always move local module imports to the top level unless lazy loading is explicitly required for significant performance or dependency-circle breaking, but wrap them appropriately when backward-compatibility with older libraries is required.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,14 +428,16 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      try:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
+      except NameError:
+        pass
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      try:
+        tags.regressor_tags = RegressorTags()
+      except NameError:
+        pass
     return tags
 
   def _more_tags(self):


### PR DESCRIPTION
**🎯 What**
Moved `ClassifierTags` and `RegressorTags` imports in `asgl/base_model.py` from method level (`__sklearn_tags__`) to the module level. Wrapped the top-level imports in `try...except ImportError: pass` and their instantiation in the method in `try...except NameError: pass` to maintain backward compatibility with older `scikit-learn` versions (pre-1.6).

**💡 Why**
This improves the structural hygiene of the file. As per Python and package hygiene best practices, imports should generally live at the top of the file unless lazy-loading is strictly necessary. This centralizes external library dependencies and improves readability without breaking compatibility.

**✅ Verification**
Ran `ruff check asgl/` which reported no errors.
Ran `pytest tests/test_skmodels.py tests/test_skmodels_sparse.py tests/test_skmodels_multi_y.py tests/test_skmodels_multi_y_sparse.py` with 107 passing tests and 2 non-failing runtime warnings.

**✨ Result**
A cleaner module-level import structure for scikit-learn tags in `asgl/base_model.py`. Added insight to `.jules/binder.md`.

---
*PR created automatically by Jules for task [6190351558642584716](https://jules.google.com/task/6190351558642584716) started by @zeyuz35*