### PR TITLE
⚡ Bolt: Replace `cp.sum(cp.multiply)` with `@` for CVXPY canonicalization performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - CVXPY Expression Tree Optimization
+**Learning:** In CVXPY, `cp.sum(cp.multiply(A, B))` builds a massive, computationally expensive element-wise multiplication expression tree when parsed by the canonicalization engine. Replacing this with a native dot product `A.T @ B` (or equivalent vector inner product operations) achieves mathematically identical results but dramatically reduces canonicalization time without impacting the final solver's execution time.
+**Action:** Always inspect CVXPY models for linear combinations disguised as element-wise multiplication loops or sum-of-multiplies, and convert them directly to dot product representations to significantly optimize problem compilation phase times.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -260,7 +260,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (
+      sqrt_sizes.T @ group_norms
+    )  # ⚡ Bolt: Using dot product (@) instead of sum(multiply()) significantly reduces CVXPY expression tree size and canonicalization time without impacting solver time.
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +273,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (
+      sqrt_sizes.T @ group_norms
+    )  # ⚡ Bolt: Using dot product (@) instead of sum(multiply()) significantly reduces CVXPY expression tree size and canonicalization time without impacting solver time.
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -183,7 +183,9 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (
+      group_weights.T @ group_norms
+    )  # ⚡ Bolt: Using dot product (@) instead of sum(multiply()) significantly reduces CVXPY expression tree size and canonicalization time without impacting solver time.
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -202,7 +204,9 @@ class Regressor(BaseModel, AdaptiveWeights):
     individual_penalization = individual_param * cp.norm1(
       cp.multiply(weights, beta_var)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (
+      group_weights.T @ group_norms
+    )  # ⚡ Bolt: Using dot product (@) instead of sum(multiply()) significantly reduces CVXPY expression tree size and canonicalization time without impacting solver time.
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
💡 What
Replaced `cp.sum(cp.multiply(weights, norms))` with `weights.T @ norms` in `asgl/regressor.py` and `asgl/base_model.py`.

🎯 Why
In CVXPY, `cp.sum(cp.multiply(A, B))` builds an extremely large expression tree that drastically increases the time spent in the canonicalization phase (compiling the problem for the solver). Using the dot product `A.T @ B` achieves the exact same mathematical constraints but compiles far more efficiently.

📊 Impact
Dramatically reduces the problem setup/compilation time for group-penalized models (`_gl`, `_sgl`, `_agl`, `_asgl`) when dealing with a high number of variables or groups. This does not negatively impact the actual solver execution time.

🧪 Measurement
Benchmarked canonicalization time for a large number of variables. The dot product version compiles consistently faster without altering correctness, verified via the test suite. All tests pass successfully.

---
*PR created automatically by Jules for task [11506999672498371040](https://jules.google.com/task/11506999672498371040) started by @zeyuz35*