### PR TITLE
📝 Docent: Resolve linting violations and docstring typo

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - targeted lint fixes and global formatters
+**Learning:** In the `asgl` repository, global auto-formatters (e.g., `ruff format`) should be avoided to preserve `git blame` and project history. Targeted linting fixes (such as `# noqa: F841`) are preferred to prevent unintended test breakage.
+**Action:** I will apply isolated code modifications strictly aligned with the specific memory rules and confirmed in the trace, rather than blindly applying formatters or broad `sed` commands across files.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -39,7 +39,7 @@ class Regressor(BaseModel, AdaptiveWeights):
       ``model='qr'``
   fit_intercept: bool, default=True,
       Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations.
-  lambda1: float, defaul=0.1
+  lambda1: float, default=0.1
       Constant that multiplies the penalization, controlling the strength. Must be a non-negative float
       i.e. in `[0, inf)`. Larger values will result in larger penalizations.
   alpha: float, default=0.5

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -465,7 +465,7 @@ def test_gl_qr():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.8, lambda1=0, solver="CLARABEL"
@@ -648,7 +648,7 @@ def test_sgl_qr():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="sgl", quantile=0.8, lambda1=0, solver="CLARABEL"
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -469,7 +469,7 @@ def test_gl_qr():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",
@@ -2024,7 +2024,7 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
🎯 What: Fixed a docstring typo (`defaul` -> `default`) in `asgl/regressor.py`, removed unused imports in `tests/test_leakage.py` and `tests/test_solver_fallback.py`, removed an extraneous `f` prefix in `tests/test_skmodels.py`, and selectively ignored unused `group_index` assignments in test files with `# noqa: F841`. Added a journal entry to `.jules/docent.md` regarding targeted lint fixes.
💡 Why: To improve code health and documentation professionalism while strictly adhering to isolated, non-functional modifications to preserve `git blame` and project history.
✅ Verification: Ran `pytest` and `ruff check` locally, confirming that all tests and linters pass without errors or unrelated changes.
✨ Result: Clean, warning-free codebase with improved documentation accuracy and an organized journal entry for future actions.

---
*PR created automatically by Jules for task [15945245634683240224](https://jules.google.com/task/15945245634683240224) started by @zeyuz35*