### PR TITLE
🗃️ Curator: Fix silent metadata loss of DataFrame column names in BaseModel.fit

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - Fix DataFrame column preservation
+**Learning:** `BaseModel.fit` incorrectly checks if `X.columns` is callable to determine if it should preserve feature names. In Pandas DataFrames, `.columns` is a property (an `Index` object), not a method. Thus, `callable(getattr(X, 'columns', None))` is always `False` for valid Pandas DataFrames, resulting in silent metadata loss (`feature_names_in_` evaluates to `None` instead of preserving the attribute).
+**Action:** Remove the `callable()` check when inspecting for `.columns` attribute to correctly preserve feature names from Pandas-like objects.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns"):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -465,7 +465,7 @@ def test_gl_qr():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.8, lambda1=0, solver="CLARABEL"
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 
@@ -1949,3 +1949,23 @@ def test_grid_search():
 
 if __name__ == "__main__":
     pytest.main()
+
+def test_dataframe_feature_names():
+    class MockDataFrame:
+        def __init__(self, data, columns):
+            self.data = np.array(data)
+            self.columns = columns
+            self.shape = self.data.shape
+            self.ndim = self.data.ndim
+
+        def __array__(self, dtype=None, copy=None):
+            return self.data
+
+    X = MockDataFrame([[1, 2], [3, 4]], ['col_a', 'col_b'])
+    y = np.array([1, 0])
+
+    model = Regressor(model="lm")
+    model.fit(X, y)
+
+    assert hasattr(model, "feature_names_in_")
+    assert list(model.feature_names_in_) == ['col_a', 'col_b']

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -469,7 +469,7 @@ def test_gl_qr():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",
@@ -670,7 +670,7 @@ def test_sgl_qr():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",
@@ -1720,7 +1720,7 @@ def test_agl_qr():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",
@@ -1951,7 +1951,7 @@ def test_asgl_qr():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",
@@ -2024,7 +2024,7 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
**🎯 What:** 
Fixed a bug in `BaseModel.fit` where it failed to preserve feature names when a Pandas DataFrame was passed. The issue was caused by incorrectly checking if `X.columns` was callable using `callable(getattr(X, "columns", None))`. In Pandas DataFrames, `.columns` is an `Index` object (property), not a method.

**🛡️ Solution:**
Removed the erroneous `callable` check. Feature names are now correctly preserved when the incoming `X` object has a `.columns` attribute.

**✅ Verification:**
- Appended `test_dataframe_feature_names` to `tests/test_skmodels.py` which passes a mock DataFrame and verifies `feature_names_in_` is populated correctly.
- Addressed auxiliary unused variable warnings found via `ruff check` (such as `group_index` `# noqa: F841`) to maintain codebase cleanliness.
- Ran and verified that `pytest` and `ruff check` both pass flawlessly.

---
*PR created automatically by Jules for task [17129340481805361928](https://jules.google.com/task/17129340481805361928) started by @zeyuz35*