### PR TITLE
📦 Binder: [dependency/structure improvement] Clean unused test imports and variables

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Fix ruff F401, F841, F541 errors
+**Learning:** `ruff check` in the CI/local environment highlights several minor hygiene issues: unused `pytest` import in `tests/test_leakage.py`, unused `numpy` in `tests/test_solver_fallback.py`, unused variables `group_index` in error tests, and an unnecessary f-string. Fixing these aligns with Binder's goal to keep the package and tests lean and compliant.
+**Action:** Use `replace_with_git_merge_diff` to surgically remove unused imports and unused variables. Remove f-strings where no variables are interpolated. Run tests and linters again to verify.

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1816,14 +1816,13 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -2024,7 +2024,6 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
🎯 What
Removed unused imports (`pytest`, `numpy`) and unused local variables (`group_index`) from test files, and removed an unnecessary f-string prefix.

💡 Why
As part of routine package hygiene (Binder persona), resolving these linter warnings (F401, F841, F541) keeps the test suite clean, reduces potential confusion for developers reading the tests, and aligns with standard best practices for minimal dependencies.

✅ Verification
Ran `source .venv/bin/activate && ruff check .` to ensure zero linting errors. Ran the full pytest suite (`source .venv/bin/activate && PYTHONPATH=. python3 -m pytest tests/`) to ensure no tests were broken by the removals.

✨ Result
A cleaner, completely lint-free test suite.

---
*PR created automatically by Jules for task [10718439392530659980](https://jules.google.com/task/10718439392530659980) started by @zeyuz35*