### PR TITLE
⚡ Bolt: Optimize CVXPY canonicalization via inner products

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Optimize CVXPY Expressions
+**Learning:** Element-wise multiplications followed by summation or norm operations in CVXPY (e.g., `cp.sum(cp.multiply(A, B))`, `cp.norm1(cp.multiply(W, B))`) drastically increase canonicalization time due to building complex expression trees.
+**Action:** Replace these patterns with vector inner products (e.g., `A @ B`, `cp.sum(W.T @ cp.abs(B))`). This shrinks canonicalization time and tree size while either maintaining or improving solve time. (But avoid replacing `cp.sum_squares(cp.multiply(W, B))` as `cp.sum_squares` handles it efficiently).

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -132,9 +132,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
         (model_prediction.shape[0] * model_prediction.shape[1],),
         order="F",
       )
-      return (1.0 / y.shape[0]) * cp.sum(
-        cp.logistic(pred_flat) - cp.multiply(y_flat, pred_flat)
-      )
+      return (1.0 / y.shape[0]) * (cp.sum(cp.logistic(pred_flat)) - (y_flat @ pred_flat))
     else:
       raise ValueError("Invalid value for model parameter.")
 
@@ -260,7 +258,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (sqrt_sizes @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +269,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (sqrt_sizes @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -170,7 +170,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.norm1(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * cp.sum(weights.T @ cp.abs(beta_var))
     return pen
 
   def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (group_weights @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -199,10 +199,8 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    individual_penalization = individual_param * cp.norm1(
-      cp.multiply(weights, beta_var)
-    )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    individual_penalization = individual_param * cp.sum(weights.T @ cp.abs(beta_var))
+    group_penalization = group_param * (group_weights @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Replaced `cp.sum(cp.multiply(A, B))` and `cp.norm1(cp.multiply(W, B))` patterns with vector inner products (`A @ B` and `cp.sum(W.T @ cp.abs(B))`) in `BaseModel` and `Regressor` classes. This shrinks the compiled expression tree size, drastically reducing CVXPY's problem canonicalization time without impacting solver execution time or functionality.

---
*PR created automatically by Jules for task [17652672589232183687](https://jules.google.com/task/17652672589232183687) started by @zeyuz35*