### PR TITLE
📝 Docent: Fix typo in regressor.py docstring

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Typo in `asgl/regressor.py` documentation
+**Learning:** Found `defaul=0.1` instead of `default=0.1` in docstrings.
+**Action:** Fix typo and run the full format and test suite. The project has test and check tools, we must ensure nothing breaks.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -39,7 +39,7 @@ class Regressor(BaseModel, AdaptiveWeights):
       ``model='qr'``
   fit_intercept: bool, default=True,
       Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations.
-  lambda1: float, defaul=0.1
+  lambda1: float, default=0.1
       Constant that multiplies the penalization, controlling the strength. Must be a non-negative float
       i.e. in `[0, inf)`. Larger values will result in larger penalizations.
   alpha: float, default=0.5


### PR DESCRIPTION
📝 Docent: Fix typo in regressor.py docstring

Corrected `defaul` to `default` in the docstring for `lambda1`
in `asgl/regressor.py`. This improves documentation clarity and
professional presentation. Also added a Docent journal entry for this fix.

---
*PR created automatically by Jules for task [14552302061996959538](https://jules.google.com/task/14552302061996959538) started by @zeyuz35*