### PR TITLE
🗃️ Curator: Fix pandas feature names extraction

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Fix feature names extraction from Pandas DataFrames
+**Learning:** In `asgl.base_model.BaseModel.fit`, feature names from Pandas DataFrames are not extracted because DataFrame `columns` are `Index` properties, not methods. The code uses `callable(getattr(X, "columns", None))` which checks if `columns` is a method, not a property.
+**Action:** Replace `and callable(getattr(X, "columns", None))` with `and not callable(getattr(X, "columns", None))` to correctly identify properties like `columns` in Pandas DataFrames.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -465,7 +465,7 @@ def test_gl_qr():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.8, lambda1=0, solver="CLARABEL"
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -469,7 +469,7 @@ def test_gl_qr():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",
@@ -2024,7 +2024,7 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
Corrected a bug in `asgl/base_model.py` where feature names from Pandas DataFrames were being ignored because `hasattr(X, 'columns') and callable(getattr(X, 'columns', None))` evaluated to `False`. Since DataFrame `columns` are `Index` properties (not methods), I changed the check to `and not callable(...)` to properly extract and preserve the metadata during model fitting. Also included minor fixes to test files to appease linters (`# noqa: F841` on unused group variables).

---
*PR created automatically by Jules for task [14397159106136326634](https://jules.google.com/task/14397159106136326634) started by @zeyuz35*