### PR TITLE
⚙️ Modernizer: Improve constant membership lookup to O(1) sets

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Use set literals for constants
+**Learning:** `asgl.constants` defines static collections like `INDIV_NONADAPTIVE`, `GROUP_ADAPTIVE`, etc. as lists. These are frequently used for membership tests like `if self.penalization in (INDIV_ADAPTIVE + GROUP_ADAPTIVE):`.
+**Action:** Convert constant arrays defined in `constants.py` to `set` for faster O(1) lookups, and use set union (or pre-combine) for combinations. Set lookups improve performance for O(1) membership checks compared to list traversal and concatenation.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -13,8 +13,7 @@ from .constants import (
   ALLOWED_MODELS,
   ALL_PENALTIES,
   ALLOWED_CANON_BACKENDS,
-  GROUP_NONADAPTIVE,
-  GROUP_ADAPTIVE,
+  GROUP_PENALTIES,
 )
 from .utils import _get_group_info
 
@@ -364,7 +363,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
       y = y.astype(int)
       self.classes_ = np.array([0, 1])  # Assuming 0 and 1 are the classes
     if (
-      self.penalization in (GROUP_NONADAPTIVE + GROUP_ADAPTIVE) and group_index is None
+      self.penalization in GROUP_PENALTIES and group_index is None
     ):
       raise ValueError(
         "The penalization provided requires fitting the model with a group_index parameter but no group_index was detected."

--- a/asgl/constants.py
+++ b/asgl/constants.py
@@ -6,12 +6,14 @@ from scipy import sparse
 ArrayOrSparse = Union[np.ndarray, sparse.spmatrix]
 
 # Define constants for penalization types
-INDIV_NONADAPTIVE = ["lasso", "ridge", "sgl"]
-INDIV_ADAPTIVE = ["alasso", "aridge", "asgl"]
-GROUP_NONADAPTIVE = ["gl", "sgl"]
-GROUP_ADAPTIVE = ["agl", "asgl"]
-ALL_PENALTIES = INDIV_NONADAPTIVE + INDIV_ADAPTIVE + GROUP_ADAPTIVE + GROUP_NONADAPTIVE
-ALLOWED_MODELS = ["lm", "qr", "logit"]
+INDIV_NONADAPTIVE = {"lasso", "ridge", "sgl"}
+INDIV_ADAPTIVE = {"alasso", "aridge", "asgl"}
+GROUP_NONADAPTIVE = {"gl", "sgl"}
+GROUP_ADAPTIVE = {"agl", "asgl"}
+GROUP_PENALTIES = GROUP_NONADAPTIVE | GROUP_ADAPTIVE
+ADAPTIVE_PENALTIES = INDIV_ADAPTIVE | GROUP_ADAPTIVE
+ALL_PENALTIES = INDIV_NONADAPTIVE | INDIV_ADAPTIVE | GROUP_ADAPTIVE | GROUP_NONADAPTIVE
+ALLOWED_MODELS = {"lm", "qr", "logit"}
 ALLOWED_WEIGHT_TECHNIQUES = {
   "pca_1",
   "pca_pct",

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -4,8 +4,7 @@ import numpy as np
 
 from .constants import (
   ArrayOrSparse,
-  INDIV_ADAPTIVE,
-  GROUP_ADAPTIVE,
+  ADAPTIVE_PENALTIES,
 )
 from .utils import _get_group_info
 from .base_model import BaseModel
@@ -213,7 +212,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_index: Optional[Sequence[int]] = None,
   ):
     self._check_attributes()
-    if self.penalization in (INDIV_ADAPTIVE + GROUP_ADAPTIVE):
+    if self.penalization in ADAPTIVE_PENALTIES:
       self.fit_weights(X, y, group_index)
     # Call the fit method of the parent class (BaseModel) to perform the main fitting logic.
     super().fit(X, y, group_index)

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -2024,7 +2024,7 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
This modernizes the internal constants representation, migrating static lists that are predominantly used for O(1) lookups into native set literals (`{""}`). It introduces explicitly combined penalty groups to cleanly prevent performance overhead from repeated runtime array concatenation inside validation or core logic, thus ensuring Python's fast O(1) lookups are fully leveraged without readability sacrifices.

---
*PR created automatically by Jules for task [1243114189476520000](https://jules.google.com/task/1243114189476520000) started by @zeyuz35*