### PR TITLE
🗃️ Curator: [data integrity/type stability fix]

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Pandas DataFrame column preservation
+**Learning:** Pandas DataFrame `.columns` attribute is an `Index` property, not a callable method. Checking `callable(getattr(X, "columns", None))` evaluates to `False`, leading to silent loss of column names during model fitting.
+**Action:** Use `not callable(getattr(X, "columns", None))` when checking if an object exposes a dataframe-like columns property to correctly preserve feature names without assuming a specific type.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
This pull request fixes a data integrity bug where Pandas DataFrame feature names were silently ignored during model fitting. 

The conditional check in `asgl.base_model.BaseModel.fit` incorrectly verified if `X.columns` was callable using `callable(getattr(X, "columns", None))`. Because Pandas DataFrame `columns` are `Index` properties rather than callable methods, this check always failed. 

The fix updates the conditional to correctly verify the object has a `columns` attribute and that it is *not* callable, ensuring `self.feature_names_in_` is properly populated for scikit-learn compatibility when fitting with DataFrames. This commit also updates the curator journal with this insight.

---
*PR created automatically by Jules for task [6631194333166189954](https://jules.google.com/task/6631194333166189954) started by @zeyuz35*