### PR TITLE
📝 Docent: Standardize docstring parameter defaults formatting

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2025-01-08 - Standardize Docstring Parameter Defaults Format
+**Learning:** The `asgl` codebase has a documentation standard where default parameter values in docstrings should be formatted consistently without spaces around the equals sign (e.g., `default='value'`, not `default = 'value'`).
+**Action:** Always check docstring parameter defaults and format them without spaces around the `=` sign when adding or updating docstrings.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -16,14 +16,14 @@ class Regressor(BaseModel, AdaptiveWeights):
   """
   Parameters
   ----------
-  model: str, default = 'lm'
+  model: str, default='lm'
       Model to be fit. Currently, accepts:
           - 'lm': linear regression models.
           - 'qr': quantile regression models.
           - 'logit': logistic regression for binary classification, output binary classification.
       Both 'lm' and 'qr' models support multivariate regression (multiple outputs),
       allowing for simultaneous fitting and coupled feature selection with grouped penalizations.
-  penalization: str or None, default = 'lasso'
+  penalization: str or None, default='lasso'
       Penalization to use. Currently, accepts:
           - None: unpenalized model.
           - 'lasso': lasso penalization.


### PR DESCRIPTION
This PR standardizes the formatting of docstring parameter defaults in `asgl/regressor.py` to ensure consistency with the established standard (`default='value'` rather than `default = 'value'`). It also creates a `.jules/docent.md` journal to document this codebase-specific documentation standard for future reference.

---
*PR created automatically by Jules for task [14217119202435048075](https://jules.google.com/task/14217119202435048075) started by @zeyuz35*