### PR TITLE
📦 Binder: move method imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Move method-level imports to module level
+**Learning:** Found method-level imports for `ClassifierTags` and `RegressorTags` in `asgl/base_model.py`. The codebase needs `try...except ImportError: pass` at module level and `try...except NameError: pass` in method to preserve compatibility with scikit-learn versions lacking these tags.
+**Action:** When finding method-level dependency imports in scikit-learn estimators, strictly move them to the top of the file wrapped with `try...except ImportError`, and use `NameError` checks where instantiated.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -18,6 +18,12 @@ from .constants import (
 )
 from .utils import _get_group_info
 
+try:
+  from sklearn.utils._tags import ClassifierTags
+  from sklearn.utils._tags import RegressorTags
+except ImportError:
+  pass
+
 
 class BaseModel(BaseEstimator, RegressorMixin):
   """
@@ -423,14 +429,16 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      try:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
+      except NameError:
+        pass
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      try:
+        tags.regressor_tags = RegressorTags()
+      except NameError:
+        pass
     return tags
 
   def _more_tags(self):

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -2024,7 +2024,7 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
📦 Binder: move method imports to module level

- Moved `ClassifierTags` and `RegressorTags` imports from `__sklearn_tags__` method to top level in `asgl/base_model.py`.
- Wrapped top-level imports in `try...except ImportError` for backwards compatibility with scikit-learn.
- Wrapped instantiations in `try...except NameError`.
- Removed unused `pytest` and `numpy` imports from test files.
- Silenced linting warnings for intentionally unused variables in tests.

---
*PR created automatically by Jules for task [8422006873458781966](https://jules.google.com/task/8422006873458781966) started by @zeyuz35*