### PR TITLE
📦 Binder: Move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Move scikit-learn tags imports to module level
+**Learning:** scikit-learn's `ClassifierTags` and `RegressorTags` are imported locally inside `__sklearn_tags__` which violates Binder guidelines. To keep compatibility, they must be imported with a try-except at the top of the module.
+**Action:** Always move local module imports to the top level unless lazy loading is explicitly required for significant performance gains or to break dependency circles. Ensure backward compatibility with older libraries by wrapping imports in `try...except ImportError` blocks when necessary.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,10 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
 
 from .constants import (
   ArrayOrSparse,
@@ -423,14 +427,16 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      try:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
+      except NameError:
+        pass
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      try:
+        tags.regressor_tags = RegressorTags()
+      except NameError:
+        pass
     return tags
 
   def _more_tags(self):


### PR DESCRIPTION
Moved local imports of ClassifierTags and RegressorTags from `__sklearn_tags__` to the top of `asgl/base_model.py` to adhere to package hygiene guidelines. Try/except blocks were added to maintain compatibility with older versions of scikit-learn.

---
*PR created automatically by Jules for task [9044462885508636693](https://jules.google.com/task/9044462885508636693) started by @zeyuz35*