### PR TITLE
🗃️ Curator: Pandas DataFrame column attribute check

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Pandas DataFrame column attribute check
+**Learning:** Pandas DataFrame columns are `Index` properties, not methods, meaning `callable(getattr(X, 'columns', None))` returns False.
+**Action:** When extracting feature names from potential DataFrames, ensure we check for `hasattr(X, 'columns') and not callable(getattr(X, 'columns', None))` to correctly preserve metadata.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixed a bug in `asgl/base_model.py` where feature names from Pandas DataFrames were not being correctly extracted. The condition previously checked if `X.columns` was `callable`, which evaluates to `False` for DataFrame `columns` because they are `Index` properties, not methods. Updated the condition to explicitly check that the attribute is `not callable` to correctly identify and preserve metadata.

---
*PR created automatically by Jules for task [17643648229084644431](https://jules.google.com/task/17643648229084644431) started by @zeyuz35*