### PR TITLE
🗃️ Curator: fix pandas feature names preservation

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-25 - [Fix feature_names_in_ preservation for pandas DataFrames]
+**Learning:** In `asgl.base_model.BaseModel.fit`, feature names from Pandas DataFrames are not preserved because the condition checks `callable(getattr(X, 'columns', None))`. Pandas `DataFrame.columns` is an `Index` property, not a method, so this evaluates to `False`.
+**Action:** Remove the `callable` check. Just check if `hasattr(X, 'columns') and not callable(getattr(X, 'columns', None))` or just check if it's an iterable and we can convert it to numpy array.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes an issue where `feature_names_in_` fails to capture column names from pandas DataFrames because `hasattr(X, "columns") and callable(getattr(X, "columns", None))` evaluates to False for properties. Replaced with `not callable(...)` to correctly handle DataFrame columns.

---
*PR created automatically by Jules for task [1813026176222747880](https://jules.google.com/task/1813026176222747880) started by @zeyuz35*