### PR TITLE
📝 Docent: [documentation/style fix] Fix docstring formatting inconsistencies in regressor.py

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fix docstring formatting inconsistencies in regressor.py
+**Learning:** Default parameter values in docstrings should be formatted consistently without spaces around the equals sign (e.g., `default='value'`, not `default = 'value'`) and typos like `defaul` need to be corrected.
+**Action:** Always ensure exact matching to standard docstring conventions in the codebase by running targeted grep checks before finalizing documentation fixes.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -16,14 +16,14 @@ class Regressor(BaseModel, AdaptiveWeights):
   """
   Parameters
   ----------
-  model: str, default = 'lm'
+  model: str, default='lm'
       Model to be fit. Currently, accepts:
           - 'lm': linear regression models.
           - 'qr': quantile regression models.
           - 'logit': logistic regression for binary classification, output binary classification.
       Both 'lm' and 'qr' models support multivariate regression (multiple outputs),
       allowing for simultaneous fitting and coupled feature selection with grouped penalizations.
-  penalization: str or None, default = 'lasso'
+  penalization: str or None, default='lasso'
       Penalization to use. Currently, accepts:
           - None: unpenalized model.
           - 'lasso': lasso penalization.
@@ -39,7 +39,7 @@ class Regressor(BaseModel, AdaptiveWeights):
       ``model='qr'``
   fit_intercept: bool, default=True,
       Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations.
-  lambda1: float, defaul=0.1
+  lambda1: float, default=0.1
       Constant that multiplies the penalization, controlling the strength. Must be a non-negative float
       i.e. in `[0, inf)`. Larger values will result in larger penalizations.
   alpha: float, default=0.5


### PR DESCRIPTION
Fix docstring formatting inconsistencies and typos in asgl/regressor.py

---
*PR created automatically by Jules for task [15087443320404918196](https://jules.google.com/task/15087443320404918196) started by @zeyuz35*