### PR TITLE
⚙️ Modernizer: Modernize CVXPY sum multiply to inner product

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,0 +1,3 @@
+## 2025-03-01 - Modernize CVXPY sum(multiply(...)) to inner product
+**Learning:** CVXPY element-wise multiplication followed by summation (`cp.sum(cp.multiply(A, B))`) is less efficient than vector inner products (`A.T @ B` or `A @ B`) which are faster and reduce canonicalization time.
+**Action:** Replace `cp.sum(cp.multiply(A, B))` with `A.T @ B` or `A @ B` (for 1D arrays, `A @ B` is sufficient) to modernize performance.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (sqrt_sizes @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (sqrt_sizes @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (group_weights @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -202,7 +202,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     individual_penalization = individual_param * cp.norm1(
       cp.multiply(weights, beta_var)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (group_weights @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Replaced `cp.sum(cp.multiply(A, B))` with the much more efficient inner product `A @ B` to improve CVXPY expression canonicalization time.

---
*PR created automatically by Jules for task [11946996284964215153](https://jules.google.com/task/11946996284964215153) started by @zeyuz35*