### PR TITLE
⚡ Bolt: Optimize CVXPY canonicalization using inner products

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-25 - Optimize CVXPY canonicalization
+**Learning:** Using `cp.sum(cp.multiply(A, B))` for 1D arrays introduces element-wise multiplication overhead during canonicalization, whereas the vector inner product `A.T @ B` dramatically shrinks the compiled expression tree and reduces canonicalization time without impacting solver execution time.
+**Action:** Replace `cp.sum(cp.multiply(A, B))` with `A.T @ B` for vector dot products in CVXPY objectives.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (sqrt_sizes.T @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (sqrt_sizes.T @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (group_weights.T @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -202,7 +202,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     individual_penalization = individual_param * cp.norm1(
       cp.multiply(weights, beta_var)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (group_weights.T @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Optimized CVXPY canonicalization by replacing element-wise multiplications with vector inner products.

---
*PR created automatically by Jules for task [15278629381050581780](https://jules.google.com/task/15278629381050581780) started by @zeyuz35*