### PR TITLE
🗃️ Curator: Fix pandas DataFrame feature names preservation in BaseModel

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fix feature names preservation for pandas DataFrames
+**Learning:** In `asgl.base_model.BaseModel.fit`, the check `callable(getattr(X, "columns", None))` incorrectly assumes that DataFrame columns are methods. In pandas, `columns` is a property (an `Index` object), so `callable` returns False. This causes silent metadata loss, where feature names are ignored.
+**Action:** Replace `callable(getattr(X, "columns", None))` with `not callable(getattr(X, "columns", None))` as described in memory, to correctly preserve pandas DataFrame feature names.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
This PR fixes a bug in `asgl.base_model.BaseModel.fit` where pandas DataFrame feature names were silently ignored. The fix correctly checks that the `columns` attribute is not callable, as it is a pandas `Index` object, ensuring feature names are preserved.

---
*PR created automatically by Jules for task [6388913632715160565](https://jules.google.com/task/6388913632715160565) started by @zeyuz35*