### PR TITLE
📦 Binder: move sklearn tag imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2025-05-25 - Moved tags import to top level
+**Learning:** scikit-learn tags related classes (`ClassifierTags`, `RegressorTags`) were imported directly inside `__sklearn_tags__`. According to Binder's boundaries, importing libraries inside function/method definitions is strictly prohibited unless there's a strong reason.
+**Action:** Move `ClassifierTags` and `RegressorTags` imports to the top level of `asgl/base_model.py`. Use a `try...except ImportError` block to handle potential backward compatibility issues with older `scikit-learn` versions if necessary, although currently the environment has scikit-learn 1.8.0.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,13 +428,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,7 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
+
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1816,14 +1816,14 @@ def test_errors():
     data = np.loadtxt(_DATA, delimiter=",", dtype=float)
     X = data[:, :-1]
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr", penalization="gl", quantile=0.2, lambda1=0.1, solver="CLARABEL"
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_skmodels_sparse.py
+++ b/tests/test_skmodels_sparse.py
@@ -2024,7 +2024,7 @@ def test_errors():
     X = data[:, :-1]
     X = sparse.csr_matrix(X)
     y = data[:, -1]
-    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])
+    group_index = np.array([1, 2, 2, 3, 3, 3, 4, 5, 5, 5])  # noqa: F841
 
     model = Regressor(
         model="qr",

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,5 @@
 import pytest
-import numpy as np
+
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
This PR implements structural improvements in the codebase to improve package hygiene, as specified by the "Binder" persona.
Key changes include:
- Refactoring `asgl/base_model.py` to move `scikit-learn` tags related classes (`ClassifierTags`, `RegressorTags`) imports from method level to the module level.
- Wrapping the tag imports in a `try...except ImportError` block to support older versions of `scikit-learn`.
- Cleaning up unused imports in the test suite to minimize dependency footprint.

---
*PR created automatically by Jules for task [10406394192868085005](https://jules.google.com/task/10406394192868085005) started by @zeyuz35*