### PR TITLE
📝 Docent: fix typo in Regressor lambda1 parameter docstring

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-26 - Fix typo in docstring
+**Learning:** Checked parameter default formatting for typos.
+**Action:** Replaced 'defaul' with 'default' in regressor.py.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -39,7 +39,7 @@ class Regressor(BaseModel, AdaptiveWeights):
       ``model='qr'``
   fit_intercept: bool, default=True,
       Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations.
-  lambda1: float, defaul=0.1
+  lambda1: float, default=0.1
       Constant that multiplies the penalization, controlling the strength. Must be a non-negative float
       i.e. in `[0, inf)`. Larger values will result in larger penalizations.
   alpha: float, default=0.5


### PR DESCRIPTION
Fixed typo in Regressor docstring for lambda1 parameter: `defaul=0.1` to `default=0.1`.

---
*PR created automatically by Jules for task [1296349341697084333](https://jules.google.com/task/1296349341697084333) started by @zeyuz35*