### PR TITLE
📦 Binder: Move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2026-05-26 - Move method-level scikit-learn tags imports to module level
+**Learning:** scikit-learn `ClassifierTags` and `RegressorTags` should be imported at the module level inside a `try...except ImportError` block to support older scikit-learn versions without these tags, preventing method-level import issues.
+**Action:** Move `ClassifierTags` and `RegressorTags` to the module level and use `try...except ImportError` in scikit-learn compatible modules.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,12 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  ClassifierTags = None
+  RegressorTags = None
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,14 +429,12 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      if ClassifierTags is not None:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      if RegressorTags is not None:
+        tags.regressor_tags = RegressorTags()
     return tags
 
   def _more_tags(self):

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1823,7 +1823,7 @@ def test_errors():
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
This PR moves the `ClassifierTags` and `RegressorTags` imports in `asgl/base_model.py` from inside the `__sklearn_tags__` method to the module level. It wraps the import in a `try...except ImportError` block to maintain backward compatibility with older `scikit-learn` versions that do not include these tags. This change adheres to package hygiene standards by removing method-level imports.

---
*PR created automatically by Jules for task [15418330999878842549](https://jules.google.com/task/15418330999878842549) started by @zeyuz35*