### PR TITLE
🗃️ Curator: Fix pandas DataFrame feature name preservation

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-27 - Fix pandas DataFrame feature name preservation
+**Learning:** In pandas DataFrames, the `columns` attribute is a property (an instance of `pd.Index`) and not a callable method. Checking `callable(getattr(X, 'columns', None))` fails when `X` is a pandas DataFrame, resulting in silent failure to preserve feature names.
+**Action:** Use `not callable(getattr(X, 'columns', None))` when checking for property-based attributes like DataFrame columns to ensure metadata preservation.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes an issue where pandas DataFrame feature names were not being preserved during model fitting because DataFrame columns are properties, not callables. The fix changes the metadata check to `not callable(getattr(X, 'columns', None))` to properly handle property-based attributes like columns.

---
*PR created automatically by Jules for task [3009491523604962441](https://jules.google.com/task/3009491523604962441) started by @zeyuz35*