### PR TITLE
📝 Docent: add missing docstrings to public APIs

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-27 - Add missing docstrings to BaseModel and Regressor
+**Learning:** The public API of scikit-learn compatible modules should always have well-defined numpydoc-style docstrings describing parameters and return values.
+**Action:** Add missing docstrings to public API methods like fit, predict, predict_proba, decision_function, and score.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -339,6 +339,23 @@ class BaseModel(BaseEstimator, RegressorMixin):
     y: ArrayOrSparse,
     group_index: Optional[Sequence[int]] = None,
   ):
+    """
+    Fit the model to the training data.
+
+    Parameters
+    ----------
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Training data.
+    y : {array-like, sparse matrix} of shape (n_samples,) or (n_samples, n_targets)
+        Target values.
+    group_index : array-like of shape (n_features,), default=None
+        Group index for each feature.
+
+    Returns
+    -------
+    self : object
+        Returns an instance of self.
+    """
     self.feature_names_in_ = None
     if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
@@ -385,6 +402,19 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return self
 
   def decision_function(self, X: ArrayOrSparse) -> np.ndarray:
+    """
+    Predict confidence scores for samples.
+
+    Parameters
+    ----------
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Samples.
+
+    Returns
+    -------
+    ndarray of shape (n_samples,) or (n_samples, n_targets)
+        Confidence scores per (sample, class) combination.
+    """
     check_is_fitted(self, ["coef_", "intercept_", "is_fitted_"])
     intercept = self.intercept_ if self.fit_intercept else 0
     predictions = (
@@ -395,6 +425,20 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return predictions
 
   def predict_proba(self, X: ArrayOrSparse) -> np.ndarray:
+    """
+    Probability estimates.
+
+    Parameters
+    ----------
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Samples.
+
+    Returns
+    -------
+    ndarray of shape (n_samples, n_classes)
+        Returns the probability of the sample for each class in the model,
+        where classes are ordered as they are in ``self.classes_``.
+    """
     if self._estimator_type != "classifier":
       raise AttributeError(
         f"predict_proba is not available when model is '{self.model}'. It is only available for classifier models."
@@ -405,6 +449,19 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return np.vstack([1 - proba_pos_class, proba_pos_class]).T
 
   def predict(self, X: ArrayOrSparse) -> np.ndarray:
+    """
+    Predict class labels or regression target for samples in X.
+
+    Parameters
+    ----------
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Samples.
+
+    Returns
+    -------
+    ndarray of shape (n_samples,) or (n_samples, n_targets)
+        Predicted class labels or values for samples.
+    """
     check_is_fitted(self, ["coef_", "intercept_", "is_fitted_"])
     raw_predictions = self.decision_function(X)
     if self._estimator_type == "classifier":
@@ -440,6 +497,23 @@ class BaseModel(BaseEstimator, RegressorMixin):
     }
 
   def score(self, X, y, sample_weight=None):
+    """
+    Return the coefficient of determination of the prediction.
+
+    Parameters
+    ----------
+    X : array-like of shape (n_samples, n_features)
+        Test samples.
+    y : array-like of shape (n_samples,) or (n_samples, n_targets)
+        True values for `X`.
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    Returns
+    -------
+    score : float
+        Score of self.predict(X) wrt. y.
+    """
     if self._estimator_type == "regressor":
       return RegressorMixin.score(self, X, y, sample_weight)
     else:  # Classifier

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -14,6 +14,8 @@ from .adaptive_weights import AdaptiveWeights
 
 class Regressor(BaseModel, AdaptiveWeights):
   """
+  Regressor model.
+
   Parameters
   ----------
   model: str, default = 'lm'
@@ -212,6 +214,23 @@ class Regressor(BaseModel, AdaptiveWeights):
     y: ArrayOrSparse,
     group_index: Optional[Sequence[int]] = None,
   ):
+    """
+    Fit the model to the training data.
+
+    Parameters
+    ----------
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        Training data.
+    y : {array-like, sparse matrix} of shape (n_samples,) or (n_samples, n_targets)
+        Target values.
+    group_index : array-like of shape (n_features,), default=None
+        Group index for each feature.
+
+    Returns
+    -------
+    self : object
+        Returns an instance of self.
+    """
     self._check_attributes()
     if self.penalization in (INDIV_ADAPTIVE + GROUP_ADAPTIVE):
       self.fit_weights(X, y, group_index)


### PR DESCRIPTION
This PR addresses documentation gaps by adding proper numpydoc-style docstrings to the core public API methods of the scikit-learn compatible estimator base classes (`BaseModel` and `Regressor`). It also resolves `pydocstyle` issues D205 and D400 in the `Regressor` class docstring. These changes do not affect any functionality but greatly improve code clarity and professional presentation.

---
*PR created automatically by Jules for task [15295424155947756868](https://jules.google.com/task/15295424155947756868) started by @zeyuz35*