### PR TITLE
📦 Binder: move sklearn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-27 - Move method-level imports to module-level
+**Learning:** scikit-learn tags (`ClassifierTags`, `RegressorTags`) were imported inside the `__sklearn_tags__` method to maintain compatibility with older `scikit-learn` versions. Moving them to the module-level blindly would break tests.
+**Action:** Always wrap module-level imports of newer external library features in `try...except ImportError` blocks and check against `None` at the call site to maintain backward compatibility while adhering to the rule against method-level imports.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,12 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  ClassifierTags = None
+  RegressorTags = None
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,14 +429,12 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      if ClassifierTags is not None:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      if RegressorTags is not None:
+        tags.regressor_tags = RegressorTags()
     return tags
 
   def _more_tags(self):


### PR DESCRIPTION
Moved sklearn tags imports to the module level inside a try-except block to improve package hygiene, prevent importing within methods, and maintain backward compatibility.

---
*PR created automatically by Jules for task [16448587720676649869](https://jules.google.com/task/16448587720676649869) started by @zeyuz35*