### PR TITLE
🗃️ Curator: [data integrity/type stability fix] Preserve DataFrame feature names during model fit

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Fix feature names extraction for Pandas DataFrames
+**Learning:** Pandas DataFrame `.columns` attribute is an `Index` object which is not callable. The previous check `callable(getattr(X, 'columns', None))` was incorrect and prevented capturing column names for pandas DataFrames, losing important metadata.
+**Action:** Use `not callable(getattr(X, 'columns', None))` to correctly identify property-like `.columns` attributes that store metadata like feature names.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fix feature name extraction for pandas DataFrames in model fit by correctly checking if the `.columns` attribute is a non-callable property rather than a callable method.

---
*PR created automatically by Jules for task [11189027528263443201](https://jules.google.com/task/11189027528263443201) started by @zeyuz35*