### PR TITLE
📦 Binder: [dependency/structure improvement] Move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - Move method-level scikit-learn tag imports to module level
+**Learning:** scikit-learn tags (`ClassifierTags`, `RegressorTags`) were imported inside `__sklearn_tags__`, violating the rule against method-level imports. Older scikit-learn versions lack these tags, which can cause `ImportError`.
+**Action:** Always place external library imports at the module level. Use `try...except ImportError` blocks for optional or version-dependent scikit-learn features to ensure compatibility with older environments.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,12 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  ClassifierTags = None
+  RegressorTags = None
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,14 +429,12 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      if ClassifierTags is not None:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      if RegressorTags is not None:
+        tags.regressor_tags = RegressorTags()
     return tags
 
   def _more_tags(self):

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,7 +1,6 @@
 import numpy as np
 from asgl import Regressor
 from sklearn.datasets import make_regression
-import pytest
 
 def test_group_weights_leakage():
     # 1. Setup first dataset

--- a/tests/test_solver_fallback.py
+++ b/tests/test_solver_fallback.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 import cvxpy as cp
 from asgl import Regressor
 from sklearn.datasets import make_regression


### PR DESCRIPTION
Move method-level imports of ClassifierTags and RegressorTags to module level within a try...except ImportError block. Remove unused imports from test files.

---
*PR created automatically by Jules for task [15242844509398435425](https://jules.google.com/task/15242844509398435425) started by @zeyuz35*