### PR TITLE
🗃️ Curator: [data integrity/type stability fix] Fix feature name preservation for pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Pandas DataFrame feature names preservation
+**Learning:** Pandas DataFrame `columns` are `Index` properties, not methods, meaning `callable(getattr(X, 'columns', None))` returns False.
+**Action:** When validating structured data objects like DataFrames, ensure that property-based attributes are checked with `not callable()` to avoid dropping metadata.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
This PR fixes a data integrity issue where Pandas DataFrame column names were incorrectly dropped during model fitting. It corrects the validation check in `asgl/base_model.py` to recognize that DataFrame `columns` are properties (not callable methods).

---
*PR created automatically by Jules for task [8653135753145065162](https://jules.google.com/task/8653135753145065162) started by @zeyuz35*