### PR TITLE
⚙️ Modernizer: optimize CVXPY canonicalization with inner products

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - Optimize CVXPY canonicalization
+**Learning:** In CVXPY, `cp.sum(cp.multiply(A, B))` and `cp.norm1(cp.multiply(A, B))` are much slower to canonicalize than using vector inner products like `A @ B` or `A.T @ cp.abs(B)` because `cp.multiply` creates element-wise nodes in the expression tree.
+**Action:** Replace `cp.sum(cp.multiply(w, norms))` with `w @ norms` and `cp.norm1(cp.multiply(w, beta))` with `np.abs(w).reshape(-1) @ cp.abs(beta)` for adaptive weights optimization. Note: `cp.sum_squares(cp.multiply(w, beta))` should not be changed as it is already optimal and canonicalizes to a single constraint.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (sqrt_sizes @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (sqrt_sizes @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -170,7 +170,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.norm1(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * cp.sum(np.abs(weights).reshape(-1) @ cp.abs(beta_var))
     return pen
 
   def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (group_weights @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -199,10 +199,10 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    individual_penalization = individual_param * cp.norm1(
-      cp.multiply(weights, beta_var)
+    individual_penalization = individual_param * cp.sum(
+      np.abs(weights).reshape(-1) @ cp.abs(beta_var)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (group_weights @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Replace element-wise multiplication norms and sums with efficient inner products for faster CVXPY canonicalization.

---
*PR created automatically by Jules for task [15476503765921678434](https://jules.google.com/task/15476503765921678434) started by @zeyuz35*