### PR TITLE
📦 Binder: Move scikit-learn tag imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Move sklearn tag imports to module level
+**Learning:** Method-level imports violate package hygiene. Backward compatibility can be maintained with try-except blocks at the module level.
+**Action:** Always place dependency imports at the top of the file, wrapped in try-except if they are version-dependent.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -18,6 +18,11 @@ from .constants import (
 )
 from .utils import _get_group_info
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  ClassifierTags, RegressorTags = None, None
+
 
 class BaseModel(BaseEstimator, RegressorMixin):
   """
@@ -423,14 +428,12 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
-      tags.classifier_tags = ClassifierTags(multi_class=False)
+      if ClassifierTags is not None:
+        tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
-      tags.regressor_tags = RegressorTags()
+      if RegressorTags is not None:
+        tags.regressor_tags = RegressorTags()
     return tags
 
   def _more_tags(self):


### PR DESCRIPTION
Moves sklearn tag imports from method level to module level wrapped in a try-except block to maintain backward compatibility while adhering to package hygiene guidelines.

---
*PR created automatically by Jules for task [17235214776411939635](https://jules.google.com/task/17235214776411939635) started by @zeyuz35*