### PR TITLE
📦 Binder: move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-31 - Move method-level imports to module level
+**Learning:** scikit-learn tags were imported inside a method (`__sklearn_tags__`) to handle missing tags in older versions, which violates explicit namespacing and creates hidden dependencies.
+**Action:** Use a module-level `try...except ImportError` block to safely import optional dependencies and keep the method bodies clean.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -16,6 +16,11 @@ from .constants import (
   GROUP_NONADAPTIVE,
   GROUP_ADAPTIVE,
 )
+try:
+    from sklearn.utils._tags import ClassifierTags, RegressorTags  # noqa: F401
+except ImportError:
+    pass
+
 from .utils import _get_group_info
 
 
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moved `ClassifierTags` and `RegressorTags` imports to the module level in `asgl/base_model.py` wrapped in a `try...except ImportError` block to maintain compatibility while adhering to explicit namespacing rules.

---
*PR created automatically by Jules for task [16392080101063187391](https://jules.google.com/task/16392080101063187391) started by @zeyuz35*