### PR TITLE
🗃️ Curator: Fix pandas DataFrame feature name extraction in BaseModel

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-06-01 - Pandas columns attribute vs callable
+**Learning:** In sklearn-compatible estimators, checking if a dataset has feature names via `hasattr(X, "columns")` requires distinguishing between pandas DataFrames (where `columns` is a property/attribute) and PySpark DataFrames (where `columns` is a callable method). Using `callable(getattr(X, "columns", None))` evaluates to False for pandas, leading to silent attribute loss if used incorrectly as a positive condition.
+**Action:** When extracting feature names, check `hasattr(X, "columns") and not callable(getattr(X, "columns", None))` to correctly identify and preserve metadata from pandas DataFrames.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes silent data loss of feature names when fitting pandas DataFrames by correctly checking that the columns attribute is not callable.

---
*PR created automatically by Jules for task [6846107280554205853](https://jules.google.com/task/6846107280554205853) started by @zeyuz35*