### PR TITLE
⚡ Bolt: Optimize CVXPY canonicalization using vector inner products

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-01 - Optimize CVXPY canonicalization using vector inner products
+**Learning:** For CVXPY performance optimization, replacing element-wise multiplications followed by summation (`cp.sum(cp.multiply(A, B))`) or norms (`cp.norm1(cp.multiply(A, B))`) with a vector inner product (`A @ B` or `np.abs(A).reshape(-1) @ cp.abs(B)`) drastically reduces canonicalization time without degrading solver execution time by heavily shrinking the compiled expression tree.
+**Action:** Use inner products instead of element-wise multiplications for summations and norms where appropriate, except for logistic regression objectives which might be adversely affected.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (np.abs(sqrt_sizes) @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (np.abs(sqrt_sizes) @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -170,7 +170,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.norm1(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * cp.sum(np.abs(weights).reshape(-1) @ cp.abs(beta_var))
     return pen
 
   def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (np.abs(group_weights) @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -199,10 +199,10 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    individual_penalization = individual_param * cp.norm1(
-      cp.multiply(weights, beta_var)
+    individual_penalization = individual_param * cp.sum(
+      np.abs(weights).reshape(-1) @ cp.abs(beta_var)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (np.abs(group_weights) @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Replaces element-wise multiplications followed by summation or L1 norm in CVXPY constraints with equivalent vector inner products, significantly improving problem canonicalization time by reducing the compiled expression tree.

---
*PR created automatically by Jules for task [10373001020328284657](https://jules.google.com/task/10373001020328284657) started by @zeyuz35*