### PR TITLE
🗃️ Curator: Fix silent metadata loss for Pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-06-01 - Fix silent metadata loss for Pandas DataFrames
+**Learning:** When extracting feature names from inputs like pandas DataFrames, use `not callable(getattr(X, 'columns', None))` to correctly distinguish them from PySpark DataFrames and prevent silent metadata loss.
+**Action:** Always verify `hasattr(X, 'columns') and not callable(getattr(X, 'columns', None))` when preserving DataFrame feature names.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fix issue in BaseModel.fit where Pandas DataFrame feature names were not being saved to feature_names_in_ due to an incorrect callable check on the columns attribute.

---
*PR created automatically by Jules for task [5148789914700722656](https://jules.google.com/task/5148789914700722656) started by @zeyuz35*