### PR TITLE
📦 Binder: Move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Module Level Imports for sklearn tags
+**Learning:** scikit-learn tags (`ClassifierTags`, `RegressorTags`) should be imported at the module level within a `try...except ImportError` block to support older versions and avoid importing inside functions.
+**Action:** Always move method-level imports to the module level.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -4,6 +4,10 @@ from sklearn.utils.validation import check_is_fitted, check_X_y, check_scalar
 import cvxpy as cp
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
@@ -423,13 +427,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
Move scikit-learn tags imports to module level within a try...except ImportError block to support older scikit-learn versions and avoid importing inside functions.

---
*PR created automatically by Jules for task [2464727503418698444](https://jules.google.com/task/2464727503418698444) started by @zeyuz35*