### PR TITLE
⚡ Bolt: Optimize cvxpy penalty canonicalization using inner products

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Replace cvxpy multiply with inner products for canonicalization speed
+**Learning:** cvxpy's `cp.multiply` canonicalization scales poorly. Inner products using `@` drastically reduce canonicalization times without affecting solver time. Constants must be explicitly strictly positive using `np.abs()` when multiplying convex functions like `cp.abs()`.
+**Action:** Always prefer `@` over `cp.sum(cp.multiply(...))` or `cp.norm1(cp.multiply(...))` for weighted sums.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (np.abs(sqrt_sizes) @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (np.abs(sqrt_sizes) @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -170,7 +170,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.norm1(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * cp.sum(np.abs(weights).reshape(-1) @ cp.abs(beta_var))
     return pen
 
   def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (np.abs(group_weights) @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -199,10 +199,10 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    individual_penalization = individual_param * cp.norm1(
-      cp.multiply(weights, beta_var)
+    individual_penalization = individual_param * cp.sum(
+      np.abs(weights).reshape(-1) @ cp.abs(beta_var)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (np.abs(group_weights) @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
⚡ **Bolt: Performance Optimization**

Identified a canonicalization bottleneck in CVXPY penalty formulations. 

**The Bottleneck:**
CVXPY represents `cp.multiply(weights, variables)` as a large set of element-wise mathematical constraints. When wrapped in a summation (`cp.sum` or `cp.norm1`), this creates a massive and slow-to-compile DCP (Disciplined Convex Programming) expression tree.

**The Fix:**
Replaced all occurrences of:
`cp.sum(cp.multiply(W, X))` and `cp.norm1(cp.multiply(W, X))`
with the mathematically equivalent matrix inner product:
`W @ X` or `np.abs(W) @ cp.abs(X)`

This mathematically equivalent operation builds a significantly smaller and more efficient canonicalized form in CVXPY, cutting down compilation time substantially before it is sent to solvers like SCS or OSQP. To maintain DCP rules, the constant weights are aggressively cast to strictly non-negative values using `np.abs()` when calculating weighted norms.

**Files modified:**
- `asgl/regressor.py`
- `asgl/base_model.py`
- `.jules/bolt.md` (Updated journal)

---
*PR created automatically by Jules for task [5486539128180646034](https://jules.google.com/task/5486539128180646034) started by @zeyuz35*