### PR TITLE
📦 Binder: Move scikit-learn tags import to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Initial\n**Learning:** Nothing yet.\n**Action:** Nothing yet.
+## 2024-05-15 - Move scikit-learn tags import to module level
+**Learning:** Moving scikit-learn tags (ClassifierTags, RegressorTags) imports to the module level in a `try...except ImportError` block improves code hygiene by removing inner imports inside methods, while preserving backwards compatibility. The `except` block should use `pass` to avoid resetting objects that are conditionally defined.
+**Action:** When modernizing scikit-learn inner imports for compatibility tags, move them to a top-level try/except block.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,10 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+try:
+    from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+    pass
 
 from .constants import (
   ArrayOrSparse,
@@ -423,12 +427,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moves inner imports of ClassifierTags and RegressorTags from the __sklearn_tags__ method to the module level in asgl/base_model.py, wrapped in a try...except ImportError block to maintain backwards compatibility with older scikit-learn versions while improving code hygiene.

---
*PR created automatically by Jules for task [4330287965616634044](https://jules.google.com/task/4330287965616634044) started by @zeyuz35*