### PR TITLE
🗃️ Curator: Fix silent metadata loss for Pandas DataFrame inputs

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Pandas feature names extraction
+**Learning:** In sklearn-compatible estimators, when extracting feature names from inputs like pandas DataFrames, `X.columns` is a property (not callable), while in PySpark DataFrames it is a method (callable). The codebase incorrectly assumed `callable(getattr(X, 'columns', None))` to extract feature names from pandas DataFrame, resulting in silent metadata loss.
+**Action:** Use `if hasattr(X, 'columns') and not callable(getattr(X, 'columns', None)):` to correctly distinguish them from PySpark DataFrames (where `columns` is callable) and prevent silent metadata loss.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Extract feature names correctly from Pandas DataFrames by updating the hasattr and callable check. Pandas DataFrame columns are properties, not callable methods.

---
*PR created automatically by Jules for task [5252266598500446761](https://jules.google.com/task/5252266598500446761) started by @zeyuz35*