### PR TITLE
⚙️ Modernizer: replace cp.sum(cp.multiply) with inner products for performance

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,0 +1,3 @@
+## 2024-06-03 - CVXPY Inner Product Optimization
+**Learning:** In CVXPY, `cp.sum(cp.multiply(A, B))` or `cp.norm1(cp.multiply(A, B))` creates a much larger expression tree than `A @ B` (or `np.abs(A) @ cp.abs(B)`). This impacts canonicalization time significantly.
+**Action:** Replace `cp.sum(cp.multiply(weights, norms))` with `np.abs(weights) @ norms` and `cp.norm1(cp.multiply(weights, vars))` with `np.abs(weights).reshape(-1) @ cp.sum(cp.abs(vars), axis=1)`. Wait, for `beta_var` which is 2D, `cp.norm1(cp.multiply(weights, beta_var))` is equivalent to `np.abs(weights).reshape(-1) @ cp.sum(cp.abs(beta_var), axis=1)`. Let's test this carefully.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (np.abs(sqrt_sizes) @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (np.abs(sqrt_sizes) @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -161,7 +161,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.sum_squares(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * (np.square(weights).reshape(-1) @ cp.sum(cp.square(beta_var), axis=1))
     return pen
 
   def _alasso(
@@ -170,7 +170,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.norm1(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * (np.abs(weights).reshape(-1) @ cp.sum(cp.abs(beta_var), axis=1))
     return pen
 
   def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (np.abs(group_weights) @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -199,10 +199,10 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    individual_penalization = individual_param * cp.norm1(
-      cp.multiply(weights, beta_var)
+    individual_penalization = individual_param * (
+      np.abs(weights).reshape(-1) @ cp.sum(cp.abs(beta_var), axis=1)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (np.abs(group_weights) @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Replaced CVXPY elementwise multiplications and sums with inner products to optimize canonicalization times.

---
*PR created automatically by Jules for task [9183359280614263244](https://jules.google.com/task/9183359280614263244) started by @zeyuz35*