### PR TITLE
⚙️ Modernizer: Replace np.dot with modern matrix multiplication operator @

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Replace np.dot with @ operator
+**Learning:** `np.dot` is used in a few places in the codebase instead of the modern, native Python matrix multiplication operator `@` (introduced in PEP 465, Python 3.5).
+**Action:** Replace `np.dot(A, B)` with `A @ B` to improve readability and embrace modern Python syntax. This reduces verbosity while maintaining the exact same functionality, fitting perfectly with the Modernizer philosophy.

--- a/asgl/adaptive_weights.py
+++ b/asgl/adaptive_weights.py
@@ -108,7 +108,7 @@ class AdaptiveWeights:
     unpenalized_model.fit(X=t, y=y)
     beta_sol = unpenalized_model.coef_
     # Recover an estimation of the beta parameters and use it as weight
-    tmp_weight = np.abs(np.dot(p, beta_sol))
+    tmp_weight = np.abs(p @ beta_sol)
     # If multi-output (2D coefficients), collapse to 1D by taking L2 norm across outputs
     if tmp_weight.ndim > 1:
       tmp_weight = np.linalg.norm(tmp_weight, axis=1)
@@ -158,7 +158,7 @@ class AdaptiveWeights:
     n_comp = np.clip(n_comp, 1, pls.x_rotations_.shape[1])
 
     # Calculate coefficients directly from the existing PLS model without refitting
-    coef = np.dot(pls.x_rotations_[:, :n_comp], pls.y_loadings_[:, :n_comp].T)
+    coef = pls.x_rotations_[:, :n_comp] @ pls.y_loadings_[:, :n_comp].T
     tmp_weight = np.abs(coef)
     # If multi-output (2D coefficients), collapse to 1D by taking L2 norm across outputs
     if tmp_weight.ndim > 1:
@@ -210,7 +210,7 @@ class AdaptiveWeights:
     unpenalized_model.fit(X=t[:, 0:n_comp], y=y)
     beta_sol = unpenalized_model.coef_
     # Recover an estimation of the beta parameters and use it as weight
-    tmp_weight = np.abs(np.dot(p[:, 0:n_comp], beta_sol))
+    tmp_weight = np.abs(p[:, 0:n_comp] @ beta_sol)
     # If multi-output (2D coefficients), collapse to 1D by taking L2 norm across outputs
     if tmp_weight.ndim > 1:
       tmp_weight = np.linalg.norm(tmp_weight, axis=1)

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -387,11 +387,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
   def decision_function(self, X: ArrayOrSparse) -> np.ndarray:
     check_is_fitted(self, ["coef_", "intercept_", "is_fitted_"])
     intercept = self.intercept_ if self.fit_intercept else 0
-    predictions = (
-      X @ self.coef_ + intercept
-      if sparse.issparse(X)
-      else np.dot(X, self.coef_) + intercept
-    )
+    predictions = X @ self.coef_ + intercept
     return predictions
 
   def predict_proba(self, X: ArrayOrSparse) -> np.ndarray:


### PR DESCRIPTION
Refactor np.dot usage to the modern native Python matrix multiplication operator @ to improve readability while maintaining the exact same functionality.

---
*PR created automatically by Jules for task [2533065598220807447](https://jules.google.com/task/2533065598220807447) started by @zeyuz35*