### PR TITLE
📦 Binder: Move sklearn tag imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-04 - Move scikit-learn tags to module level
+**Learning:** Inner function imports for specific scikit-learn classes (like `ClassifierTags` and `RegressorTags`) inside compatibility methods like `__sklearn_tags__` can degrade code readability and performance. Moving them to the module-level within a `try...except ImportError` block improves structure without breaking compatibility for environments with older scikit-learn versions.
+**Action:** Always wrap module-level imports of newer third-party library features in `try...except ImportError` blocks if the project aims to support a broader range of package versions. Use `pass` in the except block to avoid breaking original logical conditionals.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,10 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
 
 from .constants import (
   ArrayOrSparse,
@@ -423,13 +427,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
Moved inner imports of `ClassifierTags` and `RegressorTags` to the module level in `asgl/base_model.py` wrapped in a `try...except ImportError` block to maintain compatibility and improve structural hygiene.

---
*PR created automatically by Jules for task [11165473415527035021](https://jules.google.com/task/11165473415527035021) started by @zeyuz35*