### PR TITLE
🗃️ Curator: Fix silent loss of feature names from pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fix feature names extraction for pandas DataFrames
+**Learning:** The check `callable(getattr(X, "columns", None))` incorrectly fails for pandas DataFrames where `columns` is a property, leading to silent metadata loss.
+**Action:** Use `not callable(getattr(X, "columns", None))` to distinguish properties like pandas columns from callable methods.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
This PR fixes a bug where `feature_names_in_` is not extracted correctly from pandas DataFrames because `columns` is a property, not a callable.

---
*PR created automatically by Jules for task [15305954268832775690](https://jules.google.com/task/15305954268832775690) started by @zeyuz35*