### PR TITLE
📦 Binder: Move scikit-learn inner imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Move inner scikit-learn imports to module level
+**Learning:** scikit-learn tags classes like `ClassifierTags` and `RegressorTags` were imported dynamically inside `__sklearn_tags__`. It is cleaner and reduces dependency overhead per method call to attempt these imports at the module level.
+**Action:** Move inner imports to the top of the file, wrapped in `try...except ImportError` to safely support older scikit-learn versions without breaking functionality.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moved scikit-learn tag class imports to the module level with an ImportError fallback block to avoid repeated inner imports while preserving backwards compatibility.

---
*PR created automatically by Jules for task [5718199950807928777](https://jules.google.com/task/5718199950807928777) started by @zeyuz35*