### PR TITLE
🗃️ Curator: [data integrity/type stability fix] Correct attribute preservation for feature names

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2025-06-05 - Correct attribute preservation for feature names
+**Learning:** When extracting feature names from inputs like pandas DataFrames in scikit-learn compatible modules, using `hasattr(X, 'columns') and callable(getattr(X, 'columns', None))` fails because `columns` is a property, not a callable method. This causes silent loss of metadata.
+**Action:** Use `if hasattr(X, 'columns') and not callable(getattr(X, 'columns', None)):` to correctly distinguish pandas DataFrame columns from PySpark DataFrames (where columns is callable) and properly preserve feature names.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Correctly identify pandas DataFrame columns to prevent silent metadata loss of feature names during fitting.

---
*PR created automatically by Jules for task [12007502114756375561](https://jules.google.com/task/12007502114756375561) started by @zeyuz35*