### PR TITLE
🗃️ Curator: [data integrity fix] Fix silent metadata loss of feature_names_in_ from pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fix silent metadata loss for feature names
+**Learning:** The logic distinguishing pandas DataFrame structures (`columns` is an attribute) from PySpark DataFrames (`columns` is callable) was inverted, leading to silent metadata loss for standard pandas DataFrames during input validation.
+**Action:** Always verify that the property introspection matches the actual attribute semantics of the target framework (e.g., pandas DataFrame `columns` attribute should not be callable).

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fix silent metadata loss of feature_names_in_ from pandas DataFrames

Replaced `callable(getattr(X, "columns", None))` with `not callable(getattr(X, "columns", None))` in input validation to properly support pandas DataFrames, where the `.columns` attribute is an Index object, not a callable method. This prevents the silent loss of the dataframe column names metadata.

---
*PR created automatically by Jules for task [12009553713430783824](https://jules.google.com/task/12009553713430783824) started by @zeyuz35*