### PR TITLE
📦 Binder: move scikit-learn tags import to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - Move scikit-learn tags import to module level
+**Learning:** Inner imports inside method definitions (`__sklearn_tags__`) violate package hygiene and can slow down function calls. Module-level imports wrapped in `try...except ImportError` blocks with `pass` ensure compatibility with older dependencies (like scikit-learn versions without `_tags`) without adding runtime overhead on method calls.
+**Action:** Always place package dependencies at the module level. For optional or version-dependent imports, use a `try...except ImportError: pass` block at the module level rather than lazy inner imports, preserving cleaner namespacing and execution speed.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,13 +428,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
This PR moves scikit-learn tags inner imports in __sklearn_tags__ to module level inside a try-except block to improve package hygiene and avoid import overhead on method calls.

---
*PR created automatically by Jules for task [13789225712582454477](https://jules.google.com/task/13789225712582454477) started by @zeyuz35*