### PR TITLE
🗃️ Curator: Fix Pandas DataFrame metadata loss

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Fix Pandas DataFrame metadata loss
+**Learning:** `hasattr(X, "columns")` is necessary, but checking `callable(getattr(X, "columns", None))` evaluates to true in PySpark and false in Pandas, leading to silent metadata loss for Pandas inputs.
+**Action:** Use `if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):` to accurately detect pandas DataFrame features without losing metadata.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixed issue where pandas DataFrame column names were silently lost during input validation because checking `callable` on `columns` evaluated to `False` (unlike PySpark where it is a method). Altered the condition to `not callable(...)` to correctly preserve the metadata.

---
*PR created automatically by Jules for task [286440267746397372](https://jules.google.com/task/286440267746397372) started by @zeyuz35*