### PR TITLE
📦 Binder: Move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Move scikit-learn tags imports to module level
+**Learning:** In sklearn-compatible estimators, inner imports within methods can cause repeated module loading or performance hits. They should be moved to the module level.
+**Action:** Use a try...except ImportError: pass block at the top of the file to import sklearn tags classes, maintaining backward compatibility while avoiding inner imports.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Move ClassifierTags and RegressorTags imports from __sklearn_tags__ method to the module level inside a try-except ImportError block. This improves package hygiene and maintains backward compatibility.

---
*PR created automatically by Jules for task [15720592908658091213](https://jules.google.com/task/15720592908658091213) started by @zeyuz35*