### PR TITLE
⚡ Bolt: Optimize CVXPY canonicalization with inner products

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Optimize CVXPY canonicalization
+**Learning:** CVXPY canonicalization is significantly faster when using inner products instead of element-wise multiplication followed by summing or sum_squares, especially for large matrices.
+**Action:** Replace cp.sum_squares(cp.multiply(A, B)) and cp.sum(cp.multiply(A, B)) with inner products where possible to reduce expression tree sizes.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -132,8 +132,8 @@ class BaseModel(BaseEstimator, RegressorMixin):
         (model_prediction.shape[0] * model_prediction.shape[1],),
         order="F",
       )
-      return (1.0 / y.shape[0]) * cp.sum(
-        cp.logistic(pred_flat) - cp.multiply(y_flat, pred_flat)
+      return (1.0 / y.shape[0]) * (
+        cp.sum(cp.logistic(pred_flat)) - y_flat.T @ pred_flat
       )
     else:
       raise ValueError("Invalid value for model parameter.")

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -161,7 +161,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.sum_squares(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * (np.square(weights).reshape(-1) @ cp.sum(cp.square(beta_var), axis=1))
     return pen
 
   def _alasso(


### PR DESCRIPTION
Replaced `cp.multiply` with inner products in `asgl/regressor.py` and `asgl/base_model.py` to drastically improve CVXPY compilation time without degrading solver execution time.

---
*PR created automatically by Jules for task [4315419636116718407](https://jules.google.com/task/4315419636116718407) started by @zeyuz35*