### PR TITLE
📦 Binder: Move scikit-learn tag imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-08 - Move scikit-learn tag imports to module level
+**Learning:** Inner imports inside methods can cause problems and it is cleaner to keep them at the module level, wrapping them in try/except blocks to preserve compatibility with optional or newer dependencies.
+**Action:** Move inner imports to module level using try/except blocks to preserve compatibility and maintain clean namespaces.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,10 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
 
 from .constants import (
   ArrayOrSparse,
@@ -423,12 +427,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moved scikit-learn tags imports to module level to improve codebase structure and dependency hygiene.

---
*PR created automatically by Jules for task [17526064666076677108](https://jules.google.com/task/17526064666076677108) started by @zeyuz35*