### PR TITLE
🗃️ Curator: Fix DataFrame feature name extraction logic

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2025-06-09 - Fix DataFrame Feature Name Extraction Logic
+**Learning:** In sklearn-compatible estimators, when extracting feature names from inputs like pandas DataFrames, hasattr(X, 'columns') should be paired with not callable(getattr(X, 'columns', None)) to correctly distinguish them from PySpark DataFrames and prevent silent metadata loss.
+**Action:** Always verify if columns attribute is callable when extracting feature names from DataFrame-like structures to avoid type instability and metadata preservation issues.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
In sklearn-compatible estimators, when extracting feature names from inputs like pandas DataFrames, hasattr(X, 'columns') should be paired with not callable(getattr(X, 'columns', None)) to correctly distinguish them from PySpark DataFrames and prevent silent metadata loss. This PR fixes the extraction logic in BaseModel to prevent this data loss.

---
*PR created automatically by Jules for task [8592506110529722156](https://jules.google.com/task/8592506110529722156) started by @zeyuz35*