### PR TITLE
🗃️ Curator: [data integrity/type stability fix] Fix pandas feature names extraction

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Fix pandas dataframe feature names extraction
+**Learning:** In sklearn-compatible estimators, when extracting feature names from inputs like pandas DataFrames, use `if hasattr(X, 'columns') and not callable(getattr(X, 'columns', None)):` to correctly distinguish them from PySpark DataFrames (where `columns` is callable) and prevent silent metadata loss.
+**Action:** Replace `callable(getattr(X, 'columns', None))` with `not callable(getattr(X, 'columns', None))` in `asgl/base_model.py`.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fix pandas dataframe feature names extraction by using `not callable(...)` to distinguish it from PySpark DataFrames.

---
*PR created automatically by Jules for task [7914731497912988751](https://jules.google.com/task/7914731497912988751) started by @zeyuz35*