### PR TITLE
📦 Binder: Move sklearn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2025-02-13 - Move sklearn tags imports to module level
+**Learning:** Method-level imports of scikit-learn tags (ClassifierTags, RegressorTags) in `__sklearn_tags__` can be moved to the module level.
+**Action:** Use a `try...except ImportError: pass` block at the module level to handle older versions of scikit-learn while keeping the `__sklearn_tags__` logic clean and avoiding inner imports.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+    from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+    pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moved method-level scikit-learn tag imports (ClassifierTags, RegressorTags) to the module level within a try-except ImportError block in asgl/base_model.py, improving module structure while maintaining compatibility with scikit-learn.

---
*PR created automatically by Jules for task [12817412228079099717](https://jules.google.com/task/12817412228079099717) started by @zeyuz35*