### PR TITLE
📝 Docent: Remove unnecessary f-string in tests

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Fix empty f-string in tests
+**Learning:** Found an unnecessary f-string without placeholders in `tests/test_skmodels.py`, which is a style violation and caught by Ruff.
+**Action:** Remove the `f` prefix using `replace_with_git_merge_diff`.

--- a/tests/test_skmodels.py
+++ b/tests/test_skmodels.py
@@ -1823,7 +1823,7 @@ def test_errors():
     )
     with pytest.raises(
         ValueError,
-        match=f"The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
+        match="The penalization provided requires fitting the model with a group_index parameter but no group_index was detected.",
     ):
         model.fit(X, y)
 


### PR DESCRIPTION
This PR removes an f-string prefix on a string with no placeholders, resolving a Ruff F541 style violation.

---
*PR created automatically by Jules for task [1786878218911913013](https://jules.google.com/task/1786878218911913013) started by @zeyuz35*