### PR TITLE
🗃️ Curator: [data integrity/type stability fix] Preserve DataFrame feature names during model fit

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - [Fixing feature_names_in_ preservation for pandas DataFrame]
+**Learning:** In pandas DataFrames, the `columns` attribute is an Index object, not a callable method. The check `callable(getattr(X, 'columns', None))` will return `False` for pandas DataFrames, leading to silent loss of the feature names metadata when `feature_names_in_` is set to `None`. This violates Curator's rule of preserving metadata.
+**Action:** When extracting feature names from inputs like pandas DataFrames in scikit-learn compatible modules, use `not callable(getattr(X, 'columns', None))` to correctly distinguish pandas DataFrames from other data structures (like PySpark DataFrames where `columns` is callable) and ensure `feature_names_in_` is properly populated.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes the logic for extracting feature names from pandas DataFrames during model fit by checking that the 'columns' attribute is not callable.

---
*PR created automatically by Jules for task [11178511172605958824](https://jules.google.com/task/11178511172605958824) started by @zeyuz35*