### PR TITLE
🗃️ Curator: Fix silent metadata loss for pandas DataFrame feature names

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Prevent silent metadata loss for pandas DataFrames
+**Learning:** In sklearn-compatible estimators, when extracting feature names from pandas DataFrames, use `hasattr(X, 'columns') and not callable(getattr(X, 'columns', None))` to correctly distinguish them and prevent silent metadata loss.
+**Action:** Use correct attribute validation to preserve data integrity.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes silent metadata loss for pandas DataFrames by correctly identifying non-callable columns attributes.

---
*PR created automatically by Jules for task [9668029650147140117](https://jules.google.com/task/9668029650147140117) started by @zeyuz35*