### PR TITLE
📦 Binder: [dependency/structure improvement]

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Moved inner scikit-learn tags imports to module level
+**Learning:** Inner function/method imports can clutter the code and cause subtle issues. They should be moved to the module level if possible, wrapping them in `try...except ImportError` blocks if they might not be available in all supported versions of a dependency (like older scikit-learn versions).
+**Action:** Always scan for inner imports inside methods or functions and move them to the module-level namespace to keep dependency structures clean and explicit.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moved ClassifierTags and RegressorTags imports from inside the __sklearn_tags__ method to the module level, wrapping them in a try...except ImportError block to maintain compatibility while keeping the namespace explicit and dependency bloat minimal.

---
*PR created automatically by Jules for task [18115486126619227063](https://jules.google.com/task/18115486126619227063) started by @zeyuz35*