### PR TITLE
⚡ Bolt: optimize cvxpy canonicalization performance with vectorization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Optimize CVXPY canonicalization
+**Learning:** CVXPY canonicalization for element-wise multiplication followed by summation is significantly slower than using matrix multiplication due to parsing overhead.
+**Action:** Replace aggregations of element-wise array operations with vectorized matrix inner products to improve compilation and canonicalization speed.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -132,8 +132,8 @@ class BaseModel(BaseEstimator, RegressorMixin):
         (model_prediction.shape[0] * model_prediction.shape[1],),
         order="F",
       )
-      return (1.0 / y.shape[0]) * cp.sum(
-        cp.logistic(pred_flat) - cp.multiply(y_flat, pred_flat)
+      return (1.0 / y.shape[0]) * (
+        cp.sum(cp.logistic(pred_flat)) - y_flat.T @ pred_flat
       )
     else:
       raise ValueError("Invalid value for model parameter.")
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (sqrt_sizes @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (sqrt_sizes @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -161,7 +161,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.sum_squares(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * (np.square(weights).reshape(-1) @ cp.sum(cp.square(beta_var), axis=1))
     return pen
 
   def _alasso(
@@ -170,7 +170,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
     weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.norm1(cp.multiply(weights, beta_var))
+    pen = self.lambda1 * (np.abs(weights).reshape(-1) @ cp.sum(cp.abs(beta_var), axis=1))
     return pen
 
   def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -183,7 +183,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (group_weights @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -199,10 +199,10 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    individual_penalization = individual_param * cp.norm1(
-      cp.multiply(weights, beta_var)
+    individual_penalization = individual_param * (
+      np.abs(weights).reshape(-1) @ cp.sum(cp.abs(beta_var), axis=1)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (group_weights @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Replaced element-wise multiplication aggregations (like cp.multiply followed by cp.sum) with direct vector inner products (using the @ operator) in regularization terms and the logistic regression objective. This reduces CVXPY's problem canonicalization time overhead.

---
*PR created automatically by Jules for task [14991427891156589718](https://jules.google.com/task/14991427891156589718) started by @zeyuz35*