### PR TITLE
🗃️ Curator: Fix silent metadata loss for pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2025-03-09 - Fix metadata loss for pandas DataFrame inputs
+**Learning:** In sklearn-compatible estimators, when extracting feature names from inputs like pandas DataFrames, `columns` is a property, not a callable.
+**Action:** Use `if hasattr(X, 'columns') and not callable(getattr(X, 'columns', None)):` to correctly distinguish them from PySpark DataFrames (where `columns` is callable) and prevent silent metadata loss.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes an issue in BaseModel where pandas DataFrame column names were not correctly extracted as `feature_names_in_` because the code mistakenly checked if the `columns` attribute was callable.

---
*PR created automatically by Jules for task [2682618223310818569](https://jules.google.com/task/2682618223310818569) started by @zeyuz35*