### PR TITLE
📦 Binder: Move method-level sklearn tag imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Moved inner scikit-learn imports to module level
+**Learning:** Inner imports inside method definitions can hide dependencies and reduce codebase hygiene. Older scikit-learn versions may not support ClassifierTags or RegressorTags, so handling them at the module level with a try-except block is more robust.
+**Action:** Move method-level imports to the top module level when possible, utilizing fallback mechanisms like `try...except ImportError` if cross-version compatibility is needed.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -18,6 +18,11 @@ from .constants import (
 )
 from .utils import _get_group_info
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 
 class BaseModel(BaseEstimator, RegressorMixin):
   """
@@ -423,13 +428,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
Moved ClassifierTags and RegressorTags imports to module level to improve dependency visibility and organization.

---
*PR created automatically by Jules for task [12154975764382393978](https://jules.google.com/task/12154975764382393978) started by @zeyuz35*