### PR TITLE
⚡ Bolt: Optimize logistic regression canonicalization time

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Optimize logistic regression canonicalization time
+**Learning:** In CVXPY, using cp.multiply(y, pred) followed by cp.sum() for logistic regression objectives can be slow during canonicalization.
+**Action:** Replace it with the inner product y.T @ pred to significantly speed up canonicalization and execution time.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -132,8 +132,8 @@ class BaseModel(BaseEstimator, RegressorMixin):
         (model_prediction.shape[0] * model_prediction.shape[1],),
         order="F",
       )
-      return (1.0 / y.shape[0]) * cp.sum(
-        cp.logistic(pred_flat) - cp.multiply(y_flat, pred_flat)
+      return (1.0 / y.shape[0]) * (
+        cp.sum(cp.logistic(pred_flat)) - y_flat.T @ pred_flat
       )
     else:
       raise ValueError("Invalid value for model parameter.")


### PR DESCRIPTION
Use the inner product instead of element-wise multiplication and sum for the linear part of the logistic regression objective. This optimization significantly reduces the canonicalization time in CVXPY without altering the resulting convex problem.

---
*PR created automatically by Jules for task [7069364715737412528](https://jules.google.com/task/7069364715737412528) started by @zeyuz35*