### PR TITLE
📝 Docent: fix missing and malformed docstrings in regressor

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Formatting Rules
+**Learning:** The project uses 2-space indentation instead of the standard 4-space. Applying default `ruff format` breaks indentation.
+**Action:** Skip global auto-formatting and use manual targeted fixes with `pydocstyle` verification.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -1,3 +1,4 @@
+"""Module for Regressor class combining BaseModel and AdaptiveWeights."""
 from typing import Sequence, Optional, Union
 import cvxpy as cp
 import numpy as np
@@ -13,7 +14,8 @@ from .adaptive_weights import AdaptiveWeights
 
 
 class Regressor(BaseModel, AdaptiveWeights):
-  """
+  """Regression model solver using adaptive weights.
+
   Parameters
   ----------
   model: str, default = 'lm'
@@ -131,6 +133,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     verbose: bool = False,
     canon_backend: str = "CPP",
   ):
+    """Initialize the regressor model."""
     super().__init__(
       model=model,
       penalization=penalization,
@@ -212,6 +215,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     y: ArrayOrSparse,
     group_index: Optional[Sequence[int]] = None,
   ):
+    """Fit the regressor model to the provided data."""
     self._check_attributes()
     if self.penalization in (INDIV_ADAPTIVE + GROUP_ADAPTIVE):
       self.fit_weights(X, y, group_index)


### PR DESCRIPTION
I've identified missing and malformed docstrings within `asgl/regressor.py`.
The file was lacking a module docstring, and the `Regressor` class lacked a properly capitalized one-line summary docstring. In addition, the `__init__` and `fit` methods were also missing docstrings. I fixed these using simple python scripts to ensure that we pass `pydocstyle` while respecting the 2-space project indentation.

I also created `.jules/docent.md` to note the 2-space indentation rule as an insight for my journal.

---
*PR created automatically by Jules for task [1171821388677896805](https://jules.google.com/task/1171821388677896805) started by @zeyuz35*