### PR TITLE
📦 Binder: Move inner sklearn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Move scikit-learn inner imports to top level
+**Learning:** When removing inner `scikit-learn` imports (e.g., `ClassifierTags`, `RegressorTags`) from the `__sklearn_tags__` method, be careful to only remove the import statements themselves and preserve the required adjacent functional assignments. Move the imports to a module-level `try...except ImportError` block with `pass` in the except block.
+**Action:** Use a top level try-except block to optionally import classes for backward compatibility while keeping function body clean.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -18,6 +18,11 @@ from .constants import (
 )
 from .utils import _get_group_info
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 
 class BaseModel(BaseEstimator, RegressorMixin):
   """
@@ -423,13 +428,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
Moved inner sklearn tags imports to the module level inside a try-except block to support backwards compatibility and remove dependency bloat within methods.

---
*PR created automatically by Jules for task [4492170182806090868](https://jules.google.com/task/4492170182806090868) started by @zeyuz35*