### PR TITLE
🗃️ Curator: [data integrity/type stability fix] Fix silent feature name metadata loss for pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-06-13 - [Pandas DataFrame Metadata Preservation]
+**Learning:** Extracting feature names from pandas DataFrames using `callable(getattr(X, "columns", None))` evaluates to `False`, leading to silent metadata loss (`feature_names_in_ = None`), whereas PySpark DataFrames have callable columns.
+**Action:** Use `if hasattr(X, 'columns') and not callable(getattr(X, 'columns', None)):` to appropriately identify and preserve pandas feature names.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Update condition to correctly identify pandas DataFrames and preserve feature names metadata by checking that columns is not callable.

---
*PR created automatically by Jules for task [15185496930159176349](https://jules.google.com/task/15185496930159176349) started by @zeyuz35*