### PR TITLE
🗃️ Curator: Fix silent metadata loss for pandas DataFrame feature names

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Fix pandas feature names extraction
+**Learning:** In pandas DataFrames, the columns attribute is a property, not a callable method. Checking callable(getattr(X, 'columns', None)) will return False, leading to silent metadata loss when extracting feature names.
+**Action:** Use not callable(getattr(X, 'columns', None)) to properly verify that the attribute is a data property rather than a method before accessing it.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fix pandas DataFrame feature names extraction in base_model.py by inverting the callable check for the columns attribute.

---
*PR created automatically by Jules for task [8933557612632783848](https://jules.google.com/task/8933557612632783848) started by @zeyuz35*