### PR TITLE
📦 Binder: Move sklearn tag imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Module-Level Imports
+**Learning:** scikit-learn tags must be imported at module level and wrapped in a try/except block to support older scikit-learn versions without breaking.
+**Action:** Always move method-level dependencies to the module level and use try/except for backward compatibility when appropriate.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moved method-level scikit-learn tag imports to the module level in base_model.py, wrapped in a try/except block for backward compatibility.

---
*PR created automatically by Jules for task [1173961607233956782](https://jules.google.com/task/1173961607233956782) started by @zeyuz35*