### PR TITLE
⚙️ Modernizer: Update typing hints to PEP 585/604

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Type hints modernization
+**Learning:** Python 3.10+ projects can use PEP 585/604 native equivalents instead of verbose typing classes (e.g. `Union`, `Optional`, `Tuple`, `Dict`).
+**Action:** Used `str | None` instead of `Optional[str]` and `tuple` instead of `Tuple`.

--- a/asgl/adaptive_weights.py
+++ b/asgl/adaptive_weights.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Sequence, Optional, Tuple, Union
+from typing import Sequence
 from sklearn.utils.validation import check_X_y
 import numpy as np
 from sklearn.cross_decomposition import PLSRegression
@@ -31,7 +31,7 @@ class AdaptiveWeights:
     spca_ridge_alpha: float = 1e-2,
     individual_weights=None,
     group_weights=None,
-    solver: Union[str, Sequence[str]] = "CLARABEL",
+    solver: str | Sequence[str] = "CLARABEL",
     weight_tol: float = 1e-4,
     verbose: bool = False,
     canon_backend: str = "CPP",
@@ -274,7 +274,7 @@ class AdaptiveWeights:
       tmp_weight = np.linalg.norm(tmp_weight, axis=1)
     return tmp_weight
 
-  def _check_type_penalization(self) -> Tuple[bool, bool]:
+  def _check_type_penalization(self) -> tuple[bool, bool]:
     return (
       self.penalization in INDIV_ADAPTIVE,
       self.penalization in GROUP_ADAPTIVE,
@@ -284,7 +284,7 @@ class AdaptiveWeights:
     self,
     X: ArrayOrSparse,
     y: ArrayOrSparse,
-    group_index: Optional[Sequence[int]] = None,
+    group_index: Sequence[int] | None = None,
   ):
     if (
       not isinstance(self.weight_technique, str)
@@ -307,7 +307,7 @@ class AdaptiveWeights:
       raise ValueError(
         "A group penalisation was requested but `group_index` is missing."
       )
-    tmp_weight: Optional[np.ndarray] = None
+    tmp_weight: np.ndarray | None = None
     if bool_individual:
       if self.individual_weights is None:
         tmp_weight = getattr(self, "_w" + self.weight_technique)(X=X, y=y)

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Sequence, Optional, Tuple, Union
+from typing import Sequence
 from sklearn.utils.validation import check_is_fitted, check_X_y, check_scalar
 import cvxpy as cp
 import numpy as np
@@ -27,12 +27,12 @@ class BaseModel(BaseEstimator, RegressorMixin):
   def __init__(
     self,
     model: str = "lm",
-    penalization: Optional[str] = "lasso",
+    penalization: str | None = "lasso",
     quantile: float = 0.5,
     fit_intercept: bool = True,
     lambda1: float = 0.1,
     alpha: float = 0.5,
-    solver: Union[str, Sequence[str]] = "CLARABEL",
+    solver: str | Sequence[str] = "CLARABEL",
     tol: float = 1e-3,
     verbose: bool = False,
     canon_backend: str = "CPP",
@@ -243,13 +243,13 @@ class BaseModel(BaseEstimator, RegressorMixin):
 
   # Penalized problems
   def _ridge(
-    self, beta_var: cp.Variable, group_index: Optional[Sequence[int]]
+    self, beta_var: cp.Variable, group_index: Sequence[int] | None
   ) -> cp.Expression:
     pen = self.lambda1 * cp.sum_squares(beta_var)
     return pen
 
   def _lasso(
-    self, beta_var: cp.Variable, group_index: Optional[Sequence[int]]
+    self, beta_var: cp.Variable, group_index: Sequence[int] | None
   ) -> cp.Expression:
     pen = self.lambda1 * cp.norm1(beta_var)
     return pen
@@ -277,8 +277,8 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return pen
 
   def _obtain_beta(
-    self, X: ArrayOrSparse, y: ArrayOrSparse, group_index: Optional[Sequence[int]]
-  ) -> Tuple[np.ndarray, np.ndarray]:
+    self, X: ArrayOrSparse, y: ArrayOrSparse, group_index: Sequence[int] | None
+  ) -> tuple[np.ndarray, np.ndarray]:
     n = X.shape[0]
     mx = X.shape[1]
     # Ensure y is 2D for CVXPY operations
@@ -337,7 +337,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     self,
     X: ArrayOrSparse,
     y: ArrayOrSparse,
-    group_index: Optional[Sequence[int]] = None,
+    group_index: Sequence[int] | None = None,
   ):
     self.feature_names_in_ = None
     if hasattr(X, "columns") and callable(getattr(X, "columns", None)):

--- a/asgl/constants.py
+++ b/asgl/constants.py
@@ -1,9 +1,8 @@
-from typing import Union
 import numpy as np
 from scipy import sparse
 
 # Custom types
-ArrayOrSparse = Union[np.ndarray, sparse.spmatrix]
+ArrayOrSparse = np.ndarray | sparse.spmatrix
 
 # Define constants for penalization types
 INDIV_NONADAPTIVE = ["lasso", "ridge", "sgl"]

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Optional, Union
+from typing import Sequence
 import cvxpy as cp
 import numpy as np
 
@@ -111,12 +111,12 @@ class Regressor(BaseModel, AdaptiveWeights):
   def __init__(
     self,
     model: str = "lm",
-    penalization: Optional[str] = "lasso",
+    penalization: str | None = "lasso",
     quantile: float = 0.5,
     fit_intercept: bool = True,
     lambda1: float = 0.1,
     alpha: float = 0.5,
-    solver: Union[str, Sequence[str]] = "default",
+    solver: str | Sequence[str] = "default",
     weight_technique: str = "pca_pct",
     individual_power_weight: float = 1,
     group_power_weight: float = 1,
@@ -124,8 +124,8 @@ class Regressor(BaseModel, AdaptiveWeights):
     lambda1_weights: float = 0.1,
     spca_alpha: float = 1e-5,
     spca_ridge_alpha: float = 1e-2,
-    individual_weights: Optional[np.ndarray] = None,
-    group_weights: Optional[np.ndarray] = None,
+    individual_weights: np.ndarray | None = None,
+    group_weights: np.ndarray | None = None,
     weight_tol: float = 1e-4,
     tol: float = 1e-3,
     verbose: bool = False,
@@ -156,7 +156,7 @@ class Regressor(BaseModel, AdaptiveWeights):
 
   # Penalized problems
   def _aridge(
-    self, beta_var: cp.Variable, group_index: Optional[Sequence[int]]
+    self, beta_var: cp.Variable, group_index: Sequence[int] | None
   ) -> cp.Expression:
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
@@ -165,7 +165,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     return pen
 
   def _alasso(
-    self, beta_var: cp.Variable, group_index: Optional[Sequence[int]]
+    self, beta_var: cp.Variable, group_index: Sequence[int] | None
   ) -> cp.Expression:
     mx, my = beta_var.shape
     # Reshape weights to (mx, 1) for proper broadcasting across my outputs
@@ -210,7 +210,7 @@ class Regressor(BaseModel, AdaptiveWeights):
     self,
     X: ArrayOrSparse,
     y: ArrayOrSparse,
-    group_index: Optional[Sequence[int]] = None,
+    group_index: Sequence[int] | None = None,
   ):
     self._check_attributes()
     if self.penalization in (INDIV_ADAPTIVE + GROUP_ADAPTIVE):

--- a/asgl/utils.py
+++ b/asgl/utils.py
@@ -1,10 +1,9 @@
-from typing import Tuple, Dict
 import numpy as np
 
 
 def _get_group_info(
   group_index: np.ndarray,
-) -> Tuple[np.ndarray, np.ndarray, Dict[int, np.ndarray]]:
+) -> tuple[np.ndarray, np.ndarray, dict[int, np.ndarray]]:
   """
   Efficiently computes group sizes and indices for each group.
   """


### PR DESCRIPTION
Replaced legacy typing module imports (Union, Optional, Tuple, Dict) with PEP 585/604 native equivalents since Python requires >=3.10.

---
*PR created automatically by Jules for task [4540153682980922609](https://jules.google.com/task/4540153682980922609) started by @zeyuz35*