### PR TITLE
📦 Binder: Move sklearn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - Move sklearn tags imports to module level
+**Learning:** `ClassifierTags` and `RegressorTags` are imported inside the `__sklearn_tags__` method definition in `asgl/base_model.py`. This violates the rule against importing libraries inside method definitions and can cause performance issues and styling problems. However, moving them to the top might cause import errors if scikit-learn version is older and doesn't have `_tags` module.
+**Action:** Move these imports to the module level but inside a `try...except ImportError` block to safely handle different scikit-learn versions without breaking.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moved `ClassifierTags` and `RegressorTags` imports to the module level to avoid importing libraries inside method definitions, wrapped in a `try...except ImportError` to handle older `scikit-learn` versions.

---
*PR created automatically by Jules for task [3150805789062989376](https://jules.google.com/task/3150805789062989376) started by @zeyuz35*