### PR TITLE
📝 Docent: add missing docstrings to BaseModel methods

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Add missing docstrings to BaseModel methods
+**Learning:** pydocstyle expects standard API methods in scikit-learn compatible classes to have at least a one-liner summary docstring.
+**Action:** Always add simple, concise one-liner docstrings to fit, predict, __init__, and other public API methods to comply with docstring style linting without altering functionality.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -37,6 +37,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     verbose: bool = False,
     canon_backend: str = "CPP",
   ):
+    """Initialize the BaseModel."""
     self.model = model
     self.penalization = penalization
     self.quantile = quantile
@@ -339,6 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     y: ArrayOrSparse,
     group_index: Optional[Sequence[int]] = None,
   ):
+    """Fit the model to the data."""
     self.feature_names_in_ = None
     if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
@@ -385,6 +387,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return self
 
   def decision_function(self, X: ArrayOrSparse) -> np.ndarray:
+    """Compute the decision function for the data."""
     check_is_fitted(self, ["coef_", "intercept_", "is_fitted_"])
     intercept = self.intercept_ if self.fit_intercept else 0
     predictions = (
@@ -395,6 +398,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return predictions
 
   def predict_proba(self, X: ArrayOrSparse) -> np.ndarray:
+    """Predict probabilities for the data."""
     if self._estimator_type != "classifier":
       raise AttributeError(
         f"predict_proba is not available when model is '{self.model}'. It is only available for classifier models."
@@ -405,6 +409,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return np.vstack([1 - proba_pos_class, proba_pos_class]).T
 
   def predict(self, X: ArrayOrSparse) -> np.ndarray:
+    """Predict class labels or regression values for the data."""
     check_is_fitted(self, ["coef_", "intercept_", "is_fitted_"])
     raw_predictions = self.decision_function(X)
     if self._estimator_type == "classifier":
@@ -418,6 +423,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
       return raw_predictions
 
   def __sklearn_tags__(self):
+    """Return the sklearn tags for the model."""
     tags = super().__sklearn_tags__()
     tags.target_tags.required = True
     tags.target_tags.multi_output = True
@@ -440,6 +446,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     }
 
   def score(self, X, y, sample_weight=None):
+    """Return the score of the model on the data."""
     if self._estimator_type == "regressor":
       return RegressorMixin.score(self, X, y, sample_weight)
     else:  # Classifier


### PR DESCRIPTION
Adds missing one-line docstrings to standard scikit-learn API methods in BaseModel to fix pydocstyle violations.

---
*PR created automatically by Jules for task [15074324691310506056](https://jules.google.com/task/15074324691310506056) started by @zeyuz35*