### PR TITLE
🗃️ Curator: Fix silent metadata loss for pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Fix feature names extraction from pandas DataFrame
+**Learning:** When extracting feature names from pandas DataFrames, ensure the check verifies the attribute is not callable. The `.columns` attribute is a property, and checking it as a callable will evaluate to `False` and cause silent metadata loss.
+**Action:** Always check that properties are not callable when trying to extract metadata like DataFrame columns.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
This PR fixes a bug where feature names were silently dropped from DataFrames due to an incorrect callable check on the .columns property.

---
*PR created automatically by Jules for task [4365458156134447668](https://jules.google.com/task/4365458156134447668) started by @zeyuz35*