### PR TITLE
📦 Binder: move sklearn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Move sklearn tags imports to module level
+**Learning:** Found imports nested inside `__sklearn_tags__` method which violates package hygiene best practices.
+**Action:** Moved the imports to the module level and wrapped in a try/except ImportError block with `pass` in the except block to preserve functionality across different versions.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,13 +428,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
Moved scikit-learn _tags imports from method level to module level to improve package hygiene, wrapped in a try/except block for backward compatibility.

---
*PR created automatically by Jules for task [1630594114477487343](https://jules.google.com/task/1630594114477487343) started by @zeyuz35*