### PR TITLE
📝 Docent: Add missing docstrings to BaseModel API methods

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Initialize Docent Journal
+**Learning:** Repositories built with scikit-learn compatibility often require summary docstrings for standard API methods like `fit`, `predict`, and `__init__`.
+**Action:** Always verify `fit`, `predict`, `__init__`, and `score` methods have at least a one-line docstring.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -37,6 +37,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     verbose: bool = False,
     canon_backend: str = "CPP",
   ):
+    """Initialize the model."""
     self.model = model
     self.penalization = penalization
     self.quantile = quantile
@@ -339,6 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     y: ArrayOrSparse,
     group_index: Optional[Sequence[int]] = None,
   ):
+    """Fit the model to the training data."""
     self.feature_names_in_ = None
     if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
@@ -385,6 +387,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return self
 
   def decision_function(self, X: ArrayOrSparse) -> np.ndarray:
+    """Evaluate the decision function for the samples in X."""
     check_is_fitted(self, ["coef_", "intercept_", "is_fitted_"])
     intercept = self.intercept_ if self.fit_intercept else 0
     predictions = (
@@ -395,6 +398,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return predictions
 
   def predict_proba(self, X: ArrayOrSparse) -> np.ndarray:
+    """Predict class probabilities for X."""
     if self._estimator_type != "classifier":
       raise AttributeError(
         f"predict_proba is not available when model is '{self.model}'. It is only available for classifier models."
@@ -405,6 +409,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     return np.vstack([1 - proba_pos_class, proba_pos_class]).T
 
   def predict(self, X: ArrayOrSparse) -> np.ndarray:
+    """Predict class labels or regression values for X."""
     check_is_fitted(self, ["coef_", "intercept_", "is_fitted_"])
     raw_predictions = self.decision_function(X)
     if self._estimator_type == "classifier":
@@ -440,6 +445,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     }
 
   def score(self, X, y, sample_weight=None):
+    """Return the coefficient of determination or mean accuracy."""
     if self._estimator_type == "regressor":
       return RegressorMixin.score(self, X, y, sample_weight)
     else:  # Classifier


### PR DESCRIPTION
Added required one-line summary docstrings to public API methods (`__init__`, `fit`, `predict`, `predict_proba`, `decision_function`, `score`) in `asgl/base_model.py` to satisfy `pydocstyle` and improve scikit-learn compatibility.

---
*PR created automatically by Jules for task [16267454462547389572](https://jules.google.com/task/16267454462547389572) started by @zeyuz35*