### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - [Optimize CVXPY inner products]
+**Learning:** Replacing element-wise multiplication followed by sum with a direct inner product significantly reduces canonicalization time in CVXPY graph construction, especially for grouped features or large matrices.
+**Action:** Use vector/matrix multiplications instead of cp.multiply when aggregating penalized terms or calculating logit errors.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -132,8 +132,8 @@ class BaseModel(BaseEstimator, RegressorMixin):
         (model_prediction.shape[0] * model_prediction.shape[1],),
         order="F",
       )
-      return (1.0 / y.shape[0]) * cp.sum(
-        cp.logistic(pred_flat) - cp.multiply(y_flat, pred_flat)
+      return (1.0 / y.shape[0]) * (
+        cp.sum(cp.logistic(pred_flat)) - y_flat.T @ pred_flat
       )
     else:
       raise ValueError("Invalid value for model parameter.")
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (sqrt_sizes.T @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (sqrt_sizes.T @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -159,18 +159,18 @@ class Regressor(BaseModel, AdaptiveWeights):
     self, beta_var: cp.Variable, group_index: Optional[Sequence[int]]
   ) -> cp.Expression:
     mx, my = beta_var.shape
-    # Reshape weights to (mx, 1) for proper broadcasting across my outputs
-    weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.sum_squares(cp.multiply(weights, beta_var))
+    # Reshape weights to (mx,) for proper broadcasting across my outputs
+    weights = np.asarray(self.individual_weights_).reshape(-1)
+    pen = self.lambda1 * (np.square(weights) @ cp.sum(cp.square(beta_var), axis=1))
     return pen
 
   def _alasso(
     self, beta_var: cp.Variable, group_index: Optional[Sequence[int]]
   ) -> cp.Expression:
     mx, my = beta_var.shape
-    # Reshape weights to (mx, 1) for proper broadcasting across my outputs
-    weights = np.asarray(self.individual_weights_).reshape(-1, 1)
-    pen = self.lambda1 * cp.norm1(cp.multiply(weights, beta_var))
+    # Reshape weights to (mx,) for proper broadcasting across my outputs
+    weights = np.asarray(self.individual_weights_).reshape(-1)
+    pen = self.lambda1 * (np.abs(weights) @ cp.sum(cp.abs(beta_var), axis=1))
     return pen
 
   def _agl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -183,14 +183,14 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(group_weights, group_norms))
+    pen = self.lambda1 * (group_weights.T @ group_norms)
     return pen
 
   def _asgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
     individual_param = self.lambda1 * self.alpha
     mx, my = beta_var.shape
-    # Reshape individual weights to (mx, 1) for proper broadcasting across my outputs
-    weights = np.asarray(self.individual_weights_).reshape(-1, 1)
+    # Reshape individual weights to (mx,) for proper broadcasting across my outputs
+    weights = np.asarray(self.individual_weights_).reshape(-1)
     group_param = self.lambda1 * (1 - self.alpha)
     unique_groups, group_sizes, indices_per_group = _get_group_info(group_index)
     sqrt_sizes = np.sqrt(group_sizes)
@@ -199,10 +199,10 @@ class Regressor(BaseModel, AdaptiveWeights):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g], :]) for g in unique_groups]
     )
-    individual_penalization = individual_param * cp.norm1(
-      cp.multiply(weights, beta_var)
+    individual_penalization = individual_param * (
+      np.abs(weights) @ cp.sum(cp.abs(beta_var), axis=1)
     )
-    group_penalization = group_param * cp.sum(cp.multiply(group_weights, group_norms))
+    group_penalization = group_param * (group_weights.T @ group_norms)
     pen = individual_penalization + group_penalization
     return pen
 


### PR DESCRIPTION
Replaced element-wise cp.multiply followed by cp.sum with mathematical inner products (@) to drastically reduce graph parsing and canonicalization time within CVXPY during model fitting.

---
*PR created automatically by Jules for task [12789981532279989802](https://jules.google.com/task/12789981532279989802) started by @zeyuz35*