### PR TITLE
🗃️ Curator: Fix silent loss of feature names for pandas DataFrames

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2025-02-26 - Fix silent loss of feature names for pandas DataFrames
+**Learning:** In pandas, `.columns` is a property (Index object), not a method. Checking if it's callable `callable(getattr(X, 'columns', None))` will incorrectly return False, causing silent metadata loss for DataFrames.
+**Action:** When extracting feature names from pandas DataFrames, ensure the check explicitly verifies the attribute is not callable: `not callable(getattr(X, 'columns', None))` to preserve domain-specific metadata.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixed the hasattr/callable check in base_model.py to correctly identify the 'columns' property of pandas DataFrames instead of incorrectly checking if it is callable, preserving feature names.

---
*PR created automatically by Jules for task [11714807360760793435](https://jules.google.com/task/11714807360760793435) started by @zeyuz35*