### PR TITLE
📦 Binder: Move scikit-learn tag imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Module Level Imports
+**Learning:** scikit-learn tags (ClassifierTags, RegressorTags) imported inside methods can cause dependency and structure issues, violating the rule against importing libraries inside method definitions.
+**Action:** Move these imports to the module level inside a try...except ImportError block using pass in the except block to preserve functionality and backward compatibility.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,13 +428,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
Move scikit-learn tags (ClassifierTags, RegressorTags) imports from inside the __sklearn_tags__ method to the module level to improve code hygiene, following the rule against importing libraries inside method definitions. The imports are wrapped in a try...except block to maintain backward compatibility.

---
*PR created automatically by Jules for task [7448885423510400104](https://jules.google.com/task/7448885423510400104) started by @zeyuz35*