### PR TITLE
🗃️ Curator: Fix silent metadata loss of pandas feature names

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Fix pandas feature names extraction
+**Learning:** Checking pandas DataFrame .columns property as callable prevents proper extraction of feature names because it is an Index object, not a method.
+**Action:** Always check that property-like metadata attributes are not callable before accessing them to avoid silent metadata loss.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes an issue where pandas DataFrame feature names were not preserved due to an incorrect callable check on the columns attribute.

---
*PR created automatically by Jules for task [644151863298196544](https://jules.google.com/task/644151863298196544) started by @zeyuz35*