### PR TITLE
🛡️ Sentinel: Initialize security journal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Initial Review
+**Vulnerability:** None found yet.
+**Learning:** This is a numerical library that primarily uses cvxpy for optimization. It does not handle user input directly in a web context, nor does it parse complex formats like XML or YAML. It uses sklearn's input validation, which provides some safety. Need to carefully inspect if there are any subtle issues like resource exhaustion from unbounded input sizes, or division by zero, but no obvious critical security flaws exist.
+**Prevention:** N/A


### PR DESCRIPTION
This PR initializes the `.jules/sentinel.md` security journal. Following the Sentinel PRIME DIRECTIVE, since no glaring, unambiguous security issues were found in this numerical optimization library, the agent is gracefully exiting without manufacturing trivial code changes.

---
*PR created automatically by Jules for task [10134363116200533987](https://jules.google.com/task/10134363116200533987) started by @zeyuz35*