### PR TITLE
🗃️ Curator: [data integrity/type stability fix]

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-06-18 - Fix silent metadata loss when capturing feature names
+**Learning:** `getattr(X, 'columns')` on a pandas DataFrame returns a property which is not callable. Checking it as callable (`callable(getattr(X, 'columns', None))`) evaluates to `False` and causes silent metadata loss.
+**Action:** Always check that property attributes like `columns` are `not callable` to ensure they are valid data attributes and not functions.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fix silent metadata loss by correctly checking that pandas columns attribute is not callable.

---
*PR created automatically by Jules for task [8792054532469684525](https://jules.google.com/task/8792054532469684525) started by @zeyuz35*