### PR TITLE
⚡ Bolt: [performance improvement] Optimize CVXPY inner products

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Optimize CVXPY inner products
+**Learning:** CVXPY elementwise-multiplication followed by sum (`cp.sum(cp.multiply(a, b))`) is significantly slower than using the matrix multiplication operator (`a @ b`) for 1D arrays.
+**Action:** Use `@` for inner products of vectors in CVXPY to improve performance without changing mathematical semantics or DCP compliance.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -132,8 +132,8 @@ class BaseModel(BaseEstimator, RegressorMixin):
         (model_prediction.shape[0] * model_prediction.shape[1],),
         order="F",
       )
-      return (1.0 / y.shape[0]) * cp.sum(
-        cp.logistic(pred_flat) - cp.multiply(y_flat, pred_flat)
+      return (1.0 / y.shape[0]) * (
+        cp.sum(cp.logistic(pred_flat)) - y_flat @ pred_flat
       )
     else:
       raise ValueError("Invalid value for model parameter.")
@@ -260,7 +260,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    pen = self.lambda1 * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    pen = self.lambda1 * (sqrt_sizes @ group_norms)
     return pen
 
   def _sgl(self, beta_var: cp.Variable, group_index: Sequence[int]) -> cp.Expression:
@@ -271,7 +271,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_norms = cp.hstack(
       [cp.norm2(beta_var[indices_per_group[g]]) for g in unique_groups]
     )
-    group_penalization = group_param * cp.sum(cp.multiply(sqrt_sizes, group_norms))
+    group_penalization = group_param * (sqrt_sizes @ group_norms)
     individual_penalization = individual_param * cp.norm1(beta_var)
     pen = individual_penalization + group_penalization
     return pen


### PR DESCRIPTION
This PR optimizes CVXPY operations by replacing `cp.sum(cp.multiply(a, b))` with `a @ b` for 1D vectors. This avoids creating unnecessary intermediate AST nodes for elementwise multiplication, speeding up CVXPY compilation and variable formulation time while preserving DCP-compliance.

---
*PR created automatically by Jules for task [8125447499067280828](https://jules.google.com/task/8125447499067280828) started by @zeyuz35*