### PR TITLE
📦 Binder: Move inline imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Move inline imports to module level
+**Learning:** Moving conditional backward-compatibility imports (like scikit-learn's ClassifierTags and RegressorTags) out of method definitions to the module level, wrapping them in a try...except ImportError block, adheres to structural best practices while preserving compatibility.
+**Action:** Always place external package imports at the module level wrapped in appropriate error handling, rather than burying them inside method definitions.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moves conditional backward-compatibility imports for scikit-learn ClassifierTags and RegressorTags out of method definitions to the module level, wrapped in a try/except block. This adheres to structural best practices while preserving original functionality and compatibility with older library versions.

---
*PR created automatically by Jules for task [6978196231002583603](https://jules.google.com/task/6978196231002583603) started by @zeyuz35*