### PR TITLE
🗃️ Curator: [data integrity/type stability fix]

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Fix pandas DataFrame columns metadata preservation
+**Learning:** Extracting pandas .columns attribute while checking if it is callable evaluates to False because .columns is a property, causing silent metadata loss.
+**Action:** Always check not callable(getattr(X, "columns", None)) when preserving DataFrame feature names.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes silent metadata loss for pandas DataFrames by correctly checking that the .columns property is not callable before saving feature names.

---
*PR created automatically by Jules for task [14185471163763436371](https://jules.google.com/task/14185471163763436371) started by @zeyuz35*