### PR TITLE
📦 Binder: Move sklearn compatibility imports out of method

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Move sklearn conditional imports out of method definitions
+**Learning:** Conditional backward-compatibility imports (like scikit-learn's `ClassifierTags` and `RegressorTags`) should be placed at the module level using a `try...except ImportError` block, avoiding inline imports within methods.
+**Action:** Always move these compatibility imports to the top level, wrapping them in a `try...except ImportError: pass` block to adhere to structural best practices while preserving original functionality and compatibility with older library versions.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,10 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
 
 from .constants import (
   ArrayOrSparse,
@@ -423,12 +427,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moves inline backward-compatibility imports of scikit-learn tags out of the __sklearn_tags__ method definition to the module level.

---
*PR created automatically by Jules for task [7962794155108027775](https://jules.google.com/task/7962794155108027775) started by @zeyuz35*