### PR TITLE
🗃️ Curator: [data integrity/type stability fix]

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - [Fix loss of pandas feature names]
+**Learning:** Checking for pandas DataFrame attributes using `callable(getattr(X, 'columns', None))` returns `False` because `.columns` is a property, leading to silent loss of metadata (`feature_names_in_`).
+**Action:** Always verify `not callable(getattr(X, 'columns', None))` when safely checking for a property vs method.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes an issue where `feature_names_in_` is not stored when passing pandas DataFrames, because the `.columns` attribute is a property, not a callable method.

---
*PR created automatically by Jules for task [3717917305124992631](https://jules.google.com/task/3717917305124992631) started by @zeyuz35*