### PR TITLE
📦 Binder: [dependency/structure improvement]

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Avoid Inline Imports in Scikit-Learn Extension Classes
+**Learning:** Method-level imports (like `from sklearn.utils._tags import ClassifierTags` inside `__sklearn_tags__`) violate PEP 8, degrade readability, and hide dependency requirements deep within class implementations.
+**Action:** Move these conditional backward-compatibility imports to the module level inside a `try...except ImportError: pass` block to preserve original functionality while adhering to standard structural practices.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,13 +428,9 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
-
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
-
       tags.regressor_tags = RegressorTags()
     return tags
 


### PR DESCRIPTION
Move inline imports for `ClassifierTags` and `RegressorTags` to the module level in `asgl/base_model.py`.

---
*PR created automatically by Jules for task [12785496091860467005](https://jules.google.com/task/12785496091860467005) started by @zeyuz35*