### PR TITLE
📝 Docent: fix missing summary line in Regressor class docstring

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Fix pydocstyle missing summary line in class
+**Learning:** Scikit-learn estimators in this codebase might be missing summary lines in their class docstrings, causing pydocstyle D205 and D400 errors.
+**Action:** Always verify that a class docstring starts with a one-line summary ending with a period followed by a blank line before the Parameters section.

--- a/asgl/regressor.py
+++ b/asgl/regressor.py
@@ -13,7 +13,8 @@ from .adaptive_weights import AdaptiveWeights
 
 
 class Regressor(BaseModel, AdaptiveWeights):
-  """
+  """Penalized regression models using cvxpy.
+
   Parameters
   ----------
   model: str, default = 'lm'


### PR DESCRIPTION
Fixes pydocstyle D205 and D400 errors in asgl/regressor.py by adding a one-line summary to the Regressor class docstring.

---
*PR created automatically by Jules for task [14170090513139849805](https://jules.google.com/task/14170090513139849805) started by @zeyuz35*