### PR TITLE
📦 Binder: [dependency/structure improvement]

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-21 - Move scikit-learn tags imports to module level
+**Learning:** scikit-learn tags (`ClassifierTags`, `RegressorTags`) were imported inside the `__sklearn_tags__` method definition.
+**Action:** Moving conditional backward-compatibility imports out of method definitions to the module level and wrapping them in a `try...except ImportError` block improves structural hygiene and follows best practices while preserving original functionality.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -8,6 +8,11 @@ from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
 
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
+
 from .constants import (
   ArrayOrSparse,
   ALLOWED_MODELS,
@@ -423,12 +428,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
This PR refactors `asgl/base_model.py` to move the conditional imports for scikit-learn tags out of the method definition and to the module level. They are wrapped in a try/except block to preserve backward compatibility while improving code hygiene.

---
*PR created automatically by Jules for task [18064054909139296307](https://jules.google.com/task/18064054909139296307) started by @zeyuz35*