### PR TITLE
📦 Binder: [dependency/structure improvement] Move scikit-learn tags imports to module level

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - Module-level Imports
+**Learning:** Moving backward-compatibility imports out of method definitions and wrapping them in a try-except block at the module level adheres to structural best practices without breaking compatibility.
+**Action:** Always check for inline imports inside functions/methods and promote them to module level with proper try-except fallback when backward compatibility is needed.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -7,6 +7,10 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from scipy.special import expit
 from sklearn.metrics import accuracy_score
 from scipy import sparse
+try:
+  from sklearn.utils._tags import ClassifierTags, RegressorTags
+except ImportError:
+  pass
 
 from .constants import (
   ArrayOrSparse,
@@ -423,12 +427,10 @@ class BaseModel(BaseEstimator, RegressorMixin):
     tags.target_tags.multi_output = True
     if self.model == "logit":
       tags.estimator_type = "classifier"
-      from sklearn.utils._tags import ClassifierTags
 
       tags.classifier_tags = ClassifierTags(multi_class=False)
     else:
       tags.estimator_type = "regressor"
-      from sklearn.utils._tags import RegressorTags
 
       tags.regressor_tags = RegressorTags()
     return tags


### PR DESCRIPTION
Moves conditional backward-compatibility imports ClassifierTags and RegressorTags out of method definitions to the module level wrapped in a try-except block, adhering to structural best practices.

---
*PR created automatically by Jules for task [17325687225628610287](https://jules.google.com/task/17325687225628610287) started by @zeyuz35*