### PR TITLE
🗃️ Curator: Fix pandas columns attribute checking to preserve metadata

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Fix pd.DataFrame columns attribute checking
+**Learning:** Checking pandas DataFrame `columns` with `callable()` returns False and drops metadata, because it's an attribute, not a method.
+**Action:** Always check `not callable(getattr(X, 'columns', None))` to properly detect property-based metadata features.

--- a/asgl/base_model.py
+++ b/asgl/base_model.py
@@ -340,7 +340,7 @@ class BaseModel(BaseEstimator, RegressorMixin):
     group_index: Optional[Sequence[int]] = None,
   ):
     self.feature_names_in_ = None
-    if hasattr(X, "columns") and callable(getattr(X, "columns", None)):
+    if hasattr(X, "columns") and not callable(getattr(X, "columns", None)):
       self.feature_names_in_ = np.asarray(X.columns, dtype=object)
     X, y = check_X_y(
       X,


### PR DESCRIPTION
Fixes a bug where metadata is lost because the check incorrectly expects `X.columns` to be callable. Pandas DataFrame columns are properties, not methods. This change replaces `callable` with `not callable`.

---
*PR created automatically by Jules for task [13342409788360089059](https://jules.google.com/task/13342409788360089059) started by @zeyuz35*